### PR TITLE
Fix make lint error: Circular lint <- lint dependency dropped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ kurator: clean
 		cmd/kurator/main.go
 
 .PHONY: lint
-lint: lint lint-copyright
+lint: golangci-lint lint-copyright
 
 lint-copyright:
 	@${FINDFILES} \( -name '*.go' -o -name '*.cc' -o -name '*.h' -o -name '*.proto' -o -name '*.py' -o -name '*.sh' \) \( ! \( -name '*.gen.go' -o -name '*.pb.go' -o -name '*_pb2.py' \) \) -print0 |\


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
when running `make lint`, it reports an error: `Circular lint <- lint dependency dropped`
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

