### PR TITLE
clean go cache to force go test always run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,12 @@ gen-prom: clean install-tools
 	cp -r ${PROM_OUT_PATH}/manifests/* ${PROM_MANIFESTS_PATH}
 
 .PHONY: test
-test: tidy
+test: clean tidy
 	go test ./...
 
 .PHONY: clean
 clean:
+	go clean -testcache
+	go clean -cache
 	rm -rf $(OUT_PATH)
 	rm -rf $(PROM_OUT_PATH)


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
run `make test`, there's one line that shows go test uses the cache.
`ok  	kurator.dev/kurator/pkg/plugin/prometheus	(cached)`
clean cache so that we can find some occasional unit test errors, like https://github.com/kurator-dev/kurator/runs/6934243655?check_suite_focus=true
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

