### PR TITLE
fix default kubeconfig

### DIFF
--- a/pkg/generic/options.go
+++ b/pkg/generic/options.go
@@ -22,12 +22,14 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/mitchellh/cli"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/util/homedir"
 	"sigs.k8s.io/yaml"
 
 	"kurator.dev/kurator/manifests"
@@ -84,7 +86,7 @@ func (g *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&g.HomeDir, "home-dir", path.Join(homeDir, ".kurator"), "install path, default to $HOME/.kurator")
 	fs.StringVar(&g.TempDir, "temp-dir", tempDir, "file path including temporary generated files")
 
-	fs.StringVarP(&g.KubeConfig, "kubeconfig", "c", "/etc/karmada/karmada-apiserver.config", "path to the kubeconfig file, default to karmada apiserver config")
+	fs.StringVarP(&g.KubeConfig, "kubeconfig", "c", defaultKubeConfig(), "path to the kubeconfig file.")
 	fs.StringVar(&g.KubeContext, "context", "", "name of the kubeconfig context to use")
 
 	fs.BoolVar(&g.DryRun, "dry-run", false, "console/log output only, make no changes.")
@@ -133,4 +135,13 @@ func (g *Options) Errorf(format string, a ...interface{}) {
 		return
 	}
 	g.Ui.Error(fmt.Sprintf(format, a...))
+}
+
+func defaultKubeConfig() string {
+	env := os.Getenv("KUBECONFIG")
+	if env != "" {
+		return env
+	} else {
+		return filepath.Join(homedir.HomeDir(), ".kube", "config")
+	}
 }


### PR DESCRIPTION
Signed-off-by: prodan <pengshihaoren@gmail.com>

**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
**What this PR does / why we need it**:
Not every user uses `karmada`, so I think the default kubeconfig should be consistent with `kubernetes`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
```bash
prodan@ubuntu:/opt/workspaces/kurator$ ./out/linux-amd64/kurator install -h
install target component

Usage:
  kurator install [command]

Available Commands:
  istio       Install istio component
  karmada     Install karmada component
  kubeedge    Install kubeedge component
  prometheus  Install prometheus component
  volcano     Install volcano component

Flags:
  -h, --help   help for install

Global Flags:
      --context string           name of the kubeconfig context to use
      --dry-run                  console/log output only, make no changes.
      --home-dir string          install path, default to $HOME/.kurator (default "/home/prodan/.kurator")
  -c, --kubeconfig string        path to the kubeconfig file. (default "/home/prodan/.kube/config")
      --temp-dir string          file path including temporary generated files (default "/tmp/kurator1559865940")
      --wait-interval duration   interval used for checking pod ready, default value is 1s. (default 1s)
      --wait-timeout duration    timeout used for checking pod ready, default value is 2m. (default 2m0s)

Use "kurator install [command] --help" for more information about a command.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
As with kubernetes, the kubeconfig path can be set using the `KUBECONFIG` environment variable.
If the `KUBECONFIG` environment variable is not set, the default kubeconfig path is `$HOME/.kube/config`
```

