### PR TITLE
fix remove temp-dir flag

### DIFF
--- a/pkg/generic/options.go
+++ b/pkg/generic/options.go
@@ -19,7 +19,6 @@ package generic
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -41,7 +40,6 @@ type Options struct {
 	Ui cli.Ui
 	// HomeDir is an absolute path which most importantly contains "versions" installed from binary. Defaults to DefaultHomeDir
 	HomeDir string
-	TempDir string
 
 	// The interval and timeout used to check installation status.
 	WaitInterval time.Duration
@@ -77,12 +75,7 @@ func (g *Options) AddFlags(fs *pflag.FlagSet) {
 		homeDir = os.TempDir()
 	}
 
-	tempDir, err := ioutil.TempDir(os.TempDir(), "kurator")
-	if err != nil {
-		tempDir = os.TempDir()
-	}
 	fs.StringVar(&g.HomeDir, "home-dir", path.Join(homeDir, ".kurator"), "install path, default to $HOME/.kurator")
-	fs.StringVar(&g.TempDir, "temp-dir", tempDir, "file path including temporary generated files")
 
 	fs.StringVarP(&g.KubeConfig, "kubeconfig", "c", "/etc/karmada/karmada-apiserver.config", "path to the kubeconfig file, default to karmada apiserver config")
 	fs.StringVar(&g.KubeContext, "context", "", "name of the kubeconfig context to use")

--- a/pkg/plugin/istio/install.go
+++ b/pkg/plugin/istio/install.go
@@ -155,7 +155,7 @@ func (p *IstioPlugin) installCrds() error {
 		return err
 	}
 
-	tmpYamlFile := path.Join(p.options.TempDir, "manifest.yaml")
+	tmpYamlFile := path.Join(p.options.HomeDir, p.options.Components["istio"].Name, "manifest.yaml")
 	if err = os.WriteFile(tmpYamlFile, out, 0644); err != nil {
 		return err
 	}
@@ -283,7 +283,7 @@ func (p *IstioPlugin) createIstioOperatorDeployment() (kube.ResourceList, error)
 		return nil, err
 	}
 
-	tmpYamlFile := path.Join(p.options.TempDir, "istio-operator.yaml")
+	tmpYamlFile := path.Join(p.options.HomeDir, p.options.Components["istio"].Name, "istio-operator.yaml")
 	if err = os.WriteFile(tmpYamlFile, out, 0644); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
keep the temp files in istio install dir.

**Which issue(s) this PR fixes**:
Fixes #23

**Special notes for your reviewer**:
```bash
root@dev-k8s-03-master01:~# tree .kurator/                  
.kurator/
├── istio
│   ├── 1.13.3
│   │   └── istioctl
│   ├── istio-operator.yaml
│   └── manifest.yaml
└── karmada
    └── v1.1.1
        ├── kubectl-karmada
        └── LICENSE

4 directories, 5 files
root@dev-k8s-03-master01:~# ./kurator install -h
Install a target component

Usage:
  kurator install [command]

Available Commands:
  istio       Install istio component
  karmada     Install karmada component
  kubeedge    Install kubeedge component
  prometheus  Install prometheus component
  volcano     Install volcano component

Flags:
  -h, --help   help for install

Global Flags:
      --context string           name of the kubeconfig context to use
      --dry-run                  console/log output only, make no changes.
      --home-dir string          install path, default to $HOME/.kurator (default "/root/.kurator")
  -c, --kubeconfig string        path to the kubeconfig file, default to karmada apiserver config (default "/etc/karmada/karmada-apiserver.config")
      --wait-interval duration   interval used for checking pod ready, default value is 1s. (default 1s)
      --wait-timeout duration    timeout used for checking pod ready, default value is 2m. (default 2m0s)

Use "kurator install [command] --help" for more information about a command.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
remove `temp-dir` flag
```

