### PR TITLE
feat: install support karmada init flag

### DIFF
--- a/cmd/kurator/app/install/karmada/karmada.go
+++ b/cmd/kurator/app/install/karmada/karmada.go
@@ -26,12 +26,14 @@ import (
 	plugin "kurator.dev/kurator/pkg/plugin/karmada"
 )
 
+var pluginArgs = plugin.InstallArgs{}
+
 func NewCmd(opts *generic.Options) *cobra.Command {
 	karmadaCmd := &cobra.Command{
 		Use:   "karmada",
 		Short: "Install karmada component",
 		RunE: func(c *cobra.Command, args []string) error {
-			plugin, err := plugin.NewKarmadaPlugin(opts)
+			plugin, err := plugin.NewKarmadaPlugin(opts, &pluginArgs)
 			if err != nil {
 				logrus.Errorf("karmada init error: %v", err)
 				return fmt.Errorf("karmada init error: %v", err)
@@ -46,6 +48,9 @@ func NewCmd(opts *generic.Options) *cobra.Command {
 			return nil
 		},
 	}
+
+	f := karmadaCmd.PersistentFlags()
+	f.StringArrayVar(&pluginArgs.SetFlags, "set", nil, "set karmada install parameters, e.g. --set karmada-data=/etc/karmada")
 
 	return karmadaCmd
 }

--- a/pkg/plugin/join/plugin.go
+++ b/pkg/plugin/join/plugin.go
@@ -65,7 +65,7 @@ func (p *JoinPlugin) Execute(cmdArgs, environment []string) error {
 }
 
 func (p *JoinPlugin) preJoin() error {
-	karmadaPlugin, _ := karmada.NewKarmadaPlugin(p.options)
+	karmadaPlugin, _ := karmada.NewKarmadaPlugin(p.options, nil)
 	// download karmadactl
 	karmadactlPath, err := karmadaPlugin.InstallKarmadactl()
 	if err == nil {

--- a/pkg/plugin/karmada/plugin.go
+++ b/pkg/plugin/karmada/plugin.go
@@ -38,16 +38,22 @@ const (
 	aggregatedApiserverSelector = "app=karmada-aggregated-apiserver"
 )
 
+type InstallArgs struct {
+	SetFlags []string
+}
+
 type KarmadaPlugin struct {
 	*client.Client
 
 	options    *generic.Options
+	args       *InstallArgs
 	karmadactl string
 }
 
-func NewKarmadaPlugin(o *generic.Options) (*KarmadaPlugin, error) {
+func NewKarmadaPlugin(o *generic.Options, args *InstallArgs) (*KarmadaPlugin, error) {
 	p := &KarmadaPlugin{
 		options:    o,
+		args:       args,
 		karmadactl: "/usr/local/bin/kubectl-karmada",
 	}
 
@@ -94,6 +100,11 @@ func (p *KarmadaPlugin) runInstall() error {
 	installArgs := []string{
 		"init",
 	}
+
+	for _, flag := range p.args.SetFlags {
+		installArgs = append(installArgs, fmt.Sprintf("--%s", flag))
+	}
+
 	if p.options.KubeConfig != "" {
 		installArgs = append(installArgs, fmt.Sprintf("--kubeconfig=%s", p.options.KubeConfig))
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

`kurator install karmada` supports the flags of `karmada init`, set the installation flags according to the user's needs.

```bash
root@kurator-test-01:~# ./kurator install karmada -h
Install karmada component

Usage:
  kurator install karmada [flags]

Flags:
  -h, --help              help for karmada
  -s, --set stringArray   set karmada install parameters, e.g. --set karmada-data=/etc/karmada

Global Flags:
      --context string           name of the kubeconfig context to use
      --dry-run                  console/log output only, make no changes.
      --home-dir string          install path, default to $HOME/.kurator (default "/root/.kurator")
  -c, --kubeconfig string        path to the kubeconfig file, default to karmada apiserver config (default "/etc/karmada/karmada-apiserver.config")
      --wait-interval duration   interval used for checking pod ready, default value is 1s. (default 1s)
      --wait-timeout duration    timeout used for checking pod ready, default value is 2m. (default 2m0s)
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
```bash
root@kurator-test-01:~# ./kurator install karmada --set karmada-data=/etc/Karmada-test --set port=32222 --kubeconfig .kube/config   
INFO[2022-06-29 14:41:37] begin to download resource https://github.com/karmada-io/karmada/releases/download/v1.1.1/kubectl-karmada-linux-amd64.tgz -> /root/.kurator/karmada/v1.1.1 
2022-06-29T06:41:40.898940Z     info    extracted tarball into /root/.kurator/karmada/v1.1.1: 2 files, 1 dirs (2.575566708s)
I0629 14:41:40.928382   21406 deploy.go:114] kubeconfig file: .kube/config, kubernetes: https://127.0.0.1:43881
I0629 14:41:40.963329   21406 deploy.go:134] karmada apiserver ip: [172.18.0.2]
I0629 14:41:41.722650   21406 cert.go:230] Generate ca certificate success.
I0629 14:41:42.153620   21406 cert.go:230] Generate etcd-server certificate success.
I0629 14:41:42.569652   21406 cert.go:230] Generate etcd-client certificate success.
I0629 14:41:42.831359   21406 cert.go:230] Generate karmada certificate success.
I0629 14:41:42.984497   21406 cert.go:230] Generate front-proxy-ca certificate success.
I0629 14:41:43.118717   21406 cert.go:230] Generate front-proxy-client certificate success.
I0629 14:41:43.119037   21406 deploy.go:218] download crds file name: /etc/Karmada-test/crds.tar.gz
....
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`kurator install karmada` adds `--set` flag
```

