### PR TITLE
feat: add tool list subcommand

### DIFF
--- a/cmd/kurator/app/app.go
+++ b/cmd/kurator/app/app.go
@@ -24,6 +24,7 @@ import (
 
 	"kurator.dev/kurator/cmd/kurator/app/install"
 	"kurator.dev/kurator/cmd/kurator/app/join"
+	"kurator.dev/kurator/cmd/kurator/app/tool"
 	"kurator.dev/kurator/cmd/kurator/app/version"
 	"kurator.dev/kurator/pkg/generic"
 )
@@ -51,6 +52,7 @@ func NewKuratorCommand() *cobra.Command {
 	cmd.AddCommand(version.NewCmd())
 	cmd.AddCommand(install.NewCmd(o))
 	cmd.AddCommand(join.NewCmd(o))
+	cmd.AddCommand(tool.NewCmd(o))
 
 	return cmd
 }

--- a/cmd/kurator/app/tool/tool.go
+++ b/cmd/kurator/app/tool/tool.go
@@ -1,0 +1,40 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tool
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"kurator.dev/kurator/pkg/generic"
+	"kurator.dev/kurator/pkg/tool"
+)
+
+func NewCmd(opts *generic.Options) *cobra.Command {
+	toolCmd := &cobra.Command{
+		Use:                   "tool",
+		Short:                 "Tool information for the component",
+		DisableFlagsInUseLine: true,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
+	}
+
+	toolCmd.AddCommand(tool.NewListCmd(os.Stdout, opts))
+	return toolCmd
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/bramvdbogaerde/go-scp v1.2.0
+	github.com/gosuri/uitable v0.0.4
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/karmada-io/karmada v1.1.1
 	github.com/mitchellh/cli v1.1.3
@@ -113,6 +114,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
@@ -132,6 +134,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -823,6 +823,7 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 h1:uirlL/j72L93RhV4+mkWhjv0cov2I0MIgPOG9rMDr1k=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
@@ -1045,6 +1046,8 @@ github.com/mattn/go-oci8 v0.1.1/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mN
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.6/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
@@ -1267,6 +1270,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/prometheus v1.8.2-0.20220315145411-881111fec433 h1:mJmCvt45c3iQQZEljYb1Uj2A06D1YxvGTPmgY4abT/E=
 github.com/prometheus/prometheus v1.8.2-0.20220315145411-881111fec433/go.mod h1:migbGwmKEePaplmYVdzPdztaUixU4oxRYUg/JG9tiDU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/tool/list.go
+++ b/pkg/tool/list.go
@@ -1,0 +1,310 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tool
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gosuri/uitable"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+
+	"kurator.dev/kurator/pkg/generic"
+)
+
+// OutputFormat is a type for capturing supported output formats
+type OutputFormat string
+
+const (
+	Table     OutputFormat = "table"
+	TableWIDE OutputFormat = "wide"
+	JSON      OutputFormat = "json"
+	YAML      OutputFormat = "yaml"
+)
+
+// Formats returns a list of the string representation of the supported formats
+func Formats() []string {
+	return []string{Table.String(), TableWIDE.String(), JSON.String(), YAML.String()}
+}
+
+func (o OutputFormat) String() string {
+	return string(o)
+}
+
+type componentElement struct {
+	Name             string `yaml:"name"`
+	Status           string `yaml:"status"`
+	Version          string `yaml:"version"`
+	Cli              string `yaml:"cli"`
+	Hub              string `yaml:"hub"`
+	ReleaseURLPrefix string `yaml:"releaseURLPrefix"`
+}
+
+type listOptions struct {
+	options    *generic.Options
+	components map[string]componentElement
+	output     string
+}
+
+func NewListCmd(out io.Writer, opts *generic.Options) *cobra.Command {
+	o := &listOptions{
+		options: opts,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "list tool information",
+		Example: getExample(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.complete(args); err != nil {
+				return err
+			}
+
+			if err := o.validate(); err != nil {
+				return err
+			}
+
+			return o.Run(out)
+		},
+	}
+
+	// flags
+	f := cmd.PersistentFlags()
+	f.StringVarP(&o.output, "output", "o", Table.String(), fmt.Sprintf("Output format. (-o|--output=)%v", Formats()))
+
+	// completion
+	outputFlagCompletion(cmd, "output")
+
+	return cmd
+}
+
+func getExample() string {
+	return `  # List all components Cli tool.
+  kurator tool list
+
+  # List the Cli tools for all components and more information (such as tool path).
+  kurator tool list -o wide
+
+  # List specified components Cli tool.
+  kurator tool list istio karmada
+
+  # List component Cli tools in JSON output format.
+  kurator tool list -o json
+
+  # List component Cli tools in YAML output format.
+  kurator tool list -o yaml
+
+  # List a single components Cli tool in JSON output format.
+  kurator tool list istio -o json`
+}
+
+func outputFlagCompletion(cmd *cobra.Command, flag string) {
+	if err := cmd.RegisterFlagCompletionFunc(flag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return Formats(), cobra.ShellCompDirectiveDefault
+	}); err != nil {
+		logrus.Warn(err)
+	}
+}
+
+func (l *listOptions) complete(args []string) error {
+	l.components = make(map[string]componentElement)
+
+	if len(args) != 0 {
+		return l.specifiedComponent(args)
+	}
+
+	for k, v := range l.options.Components {
+		if cliToolName(k) == "" {
+			delete(l.options.Components, k)
+			continue
+		}
+		l.add(k, v)
+	}
+
+	return nil
+}
+
+func (l *listOptions) validate() error {
+	if len(l.components) == 0 {
+		return fmt.Errorf("components have no cli tool")
+	}
+
+	return nil
+}
+
+func (l *listOptions) specifiedComponent(args []string) error {
+	for _, v := range args {
+		if cliToolName(v) == "" {
+			continue
+		}
+
+		l.add(v, l.options.Components[v])
+	}
+
+	return nil
+}
+
+func (l *listOptions) add(name string, v generic.Component) {
+	status, cliPath := toolsStatus(filepath.Join(l.options.HomeDir, v.Name, v.Version, cliToolName(name)))
+	l.components[name] = componentElement{
+		Name:             v.Name,
+		Status:           status,
+		Version:          v.Version,
+		Cli:              cliPath,
+		Hub:              v.Hub,
+		ReleaseURLPrefix: v.ReleaseURLPrefix,
+	}
+}
+
+func (l *listOptions) Run(out io.Writer) error {
+	cs, err := yaml.Marshal(l.components)
+	if err != nil {
+		return fmt.Errorf("conversion failed. %v", err)
+	}
+
+	w := &toolListWriter{
+		cs: cs,
+	}
+
+	for _, v := range l.components {
+		w.entry = append(w.entry, v)
+	}
+	// sort by component name
+	sort.Slice(w.entry, func(i, j int) bool {
+		return w.entry[i].Name < w.entry[j].Name
+	})
+
+	return w.PrintObj(out, l.output)
+}
+
+type toolListWriter struct {
+	entry []componentElement
+	cs    []byte
+}
+
+func (t *toolListWriter) writeTable(out io.Writer) error {
+	table := uitable.New()
+
+	table.AddRow("NAME", "VERSION", "STATUS")
+	for _, te := range t.entry {
+		table.AddRow(te.Name, te.Version, te.Status)
+	}
+
+	return t.encodeTable(out, table)
+}
+
+func (t *toolListWriter) writeTableWIDE(out io.Writer) error {
+	table := uitable.New()
+
+	table.AddRow("NAME", "VERSION", "STATUS", "CLI", "HUB", "RELEASE-URL-PREFIX")
+	for _, te := range t.entry {
+		table.AddRow(te.Name, te.Version, te.Status, te.Cli, te.Hub, te.ReleaseURLPrefix)
+	}
+
+	return t.encodeTable(out, table)
+}
+
+func (t *toolListWriter) encodeTable(out io.Writer, table *uitable.Table) error {
+	raw := table.Bytes()
+	raw = append(raw, []byte("\n")...)
+	_, err := out.Write(raw)
+	if err != nil {
+		return fmt.Errorf("unable to write table output. %v", err)
+	}
+	return nil
+}
+
+func (t *toolListWriter) writeJSON(out io.Writer) error {
+	js, err := yaml.YAMLToJSON(t.cs)
+	if err != nil {
+		return fmt.Errorf("yaml cannot convert json. %v", err)
+	}
+
+	var prettyJSON bytes.Buffer
+	if err := json.Indent(&prettyJSON, js, "", "\t"); err != nil {
+		return fmt.Errorf("can't format json. %v", err)
+	}
+
+	if _, err := prettyJSON.WriteTo(out); err != nil {
+		return fmt.Errorf("unable to write json output. %v", err)
+	}
+	return nil
+}
+
+func (t *toolListWriter) writeYAML(out io.Writer) error {
+	if _, err := out.Write(t.cs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *toolListWriter) PrintObj(out io.Writer, format string) error {
+	switch strings.ToLower(format) {
+	case Table.String():
+		return t.writeTable(out)
+	case TableWIDE.String():
+		return t.writeTableWIDE(out)
+	case JSON.String():
+		return t.writeJSON(out)
+	case YAML.String():
+		return t.writeYAML(out)
+	}
+
+	return fmt.Errorf("invalid format type")
+}
+
+// cliToolName returns the Cli name of the component
+// When the newly added component has cli, need to add cli name.
+func cliToolName(componentName string) string {
+	switch strings.ToLower(componentName) {
+	case "istio":
+		return "istioctl"
+	case "karmada":
+		return "kubectl-karmada"
+	case "submariner":
+		return "subctl"
+	case "kubeedge":
+		return "keadm"
+	case "argocd":
+		return "argocd"
+	default:
+		return ""
+	}
+}
+
+func toolsStatus(path string) (string, string) {
+	if !exists(path) {
+		return "NotReady", ""
+	}
+	return "Ready", path
+}
+
+func exists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return os.IsExist(err)
+	}
+	return true
+}

--- a/pkg/tool/list_test.go
+++ b/pkg/tool/list_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tool
+
+import (
+	"os"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func TestPrintObj(t *testing.T) {
+	component := make(map[string]componentElement)
+	component["istio"] = componentElement{
+		Name:             "istio",
+		Cli:              "/home/root/.kurator/istio/1.13.3/istioctl",
+		Hub:              "docker.io/istio",
+		ReleaseURLPrefix: "https://github.com/istio/istio/releases/download",
+		Version:          "1.13.3",
+		Status:           "NotReady",
+	}
+	component["karmada"] = componentElement{
+		Cli:              "/home/root/.kurator/karmada/v1.2.1/kubectl-karmada",
+		Hub:              "",
+		Name:             "karmada",
+		ReleaseURLPrefix: "https://github.com/karmada-io/karmada/releases/download",
+		Version:          "v1.2.1",
+		Status:           "Ready",
+	}
+
+	cs, err := yaml.Marshal(component)
+	if err != nil {
+		panic(err)
+	}
+
+	w := &toolListWriter{
+		cs: cs,
+	}
+	for _, v := range component {
+		w.entry = append(w.entry, v)
+	}
+
+	if err := w.PrintObj(os.Stdout, Table.String()); err != nil {
+		panic(err)
+	}
+
+	if err := w.PrintObj(os.Stdout, TableWIDE.String()); err != nil {
+		panic(err)
+	}
+
+	if err := w.PrintObj(os.Stdout, YAML.String()); err != nil {
+		panic(err)
+	}
+
+	if err := w.PrintObj(os.Stdout, JSON.String()); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Signed-off-by: prodan <pengshihaoren@gmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
List the version and other information of the cli tool of the component

**Which issue(s) this PR fixes**:
Fixes #24 

**Special notes for your reviewer**:
```
/opt/workspaces/kurator$ ./out/linux-amd64/kurator tool list -h
list tool information

Usage:
  kurator tool list [flags]

Aliases:
  list, ls

Examples:
  # List all components Cli tool.
  kurator tool list

  # List the Cli tools for all components and more information (such as tool path).
  kurator tool list -o wide

  # List specified components Cli tool.
  kurator tool list istio karmada

  # List component Cli tools in JSON output format.
  kurator tool list -o json

  # List component Cli tools in YAML output format.
  kurator tool list -o yaml

  # List a single components Cli tool in JSON output format.
  kurator tool list istio -o json


Flags:
  -h, --help            help for list
  -o, --output string   Output format. (-o|--output=)[table wide json yaml] (default "table")

Global Flags:
      --context string           name of the kubeconfig context to use
      --dry-run                  console/log output only, make no changes.
      --home-dir string          install path, default to $HOME/.kurator (default "/home/prodan/.kurator")
  -c, --kubeconfig string        path to the kubeconfig file, default to karmada apiserver config (default "/etc/karmada/karmada-apiserver.config")
      --wait-interval duration   interval used for checking pod ready, default value is 1s. (default 1s)
      --wait-timeout duration    timeout used for checking pod ready, default value is 2m. (default 2m0s)
```
table output
```
/opt/workspaces/kurator$ ./out/linux-amd64/kurator tool list 
NAME            VERSION STATUS       
istio           1.13.3  Ready        
karmada         v1.2.1  NotDownloaded
kubeedge        1.10.0  NotDownloaded
submariner      v0.12.2 NotDownloaded
/opt/workspaces/kurator$ ./out/linux-amd64/kurator tool list -o wide
NAME            VERSION STATUS          CLI                                             HUB                     RELEASE-URL-PREFIX                                         
istio           1.13.3  Ready           /home/prodan/.kurator/istio/1.13.3/istioctl     docker.io/istio         https://github.com/istio/istio/releases/download           
karmada         v1.2.1  NotDownloaded                                                                           https://github.com/karmada-io/karmada/releases/download    
kubeedge        1.10.0  NotDownloaded                                                   docker.io/kebeedge      https://github.com/kubeedge/kubeedge/releases/download     
submariner      v0.12.2 NotDownloaded                                                                           https://github.com/submariner-io/releases/releases/download
```
json output
```
/opt/workspaces/kurator$ ./out/linux-amd64/kurator tool list istio karmada -o json
{
        "istio": {
                "Cli": "/home/prodan/.kurator/istio/1.13.3/istioctl",
                "Hub": "docker.io/istio",
                "Name": "istio",
                "ReleaseURLPrefix": "https://github.com/istio/istio/releases/download",
                "Status": "Ready",
                "Version": "1.13.3"
        },
        "karmada": {
                "Cli": "",
                "Hub": "",
                "Name": "karmada",
                "ReleaseURLPrefix": "https://github.com/karmada-io/karmada/releases/download",
                "Status": "NotDownloaded",
                "Version": "v1.2.1"
        }
}
```
yaml output
```
/opt/workspaces/kurator$ ./out/linux-amd64/kurator tool list istio karmada -o yaml
istio:
  Cli: /home/prodan/.kurator/istio/1.13.3/istioctl
  Hub: docker.io/istio
  Name: istio
  ReleaseURLPrefix: https://github.com/istio/istio/releases/download
  Status: Ready
  Version: 1.13.3
karmada:
  Cli: ""
  Hub: ""
  Name: karmada
  ReleaseURLPrefix: https://github.com/karmada-io/karmada/releases/download
  Status: NotDownloaded
  Version: v1.2.1
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
add `kurator tool list` subcommand
```
