### PR TITLE
istio: fix istio idempotent

### DIFF
--- a/pkg/plugin/istio/install.go
+++ b/pkg/plugin/istio/install.go
@@ -148,6 +148,7 @@ func (p *IstioPlugin) createIstioCacerts() error {
 	if err == nil {
 		// skip create cacerts if exists
 		logrus.Infof("secret %s already exists, skipping create", caSecret)
+		s.TypeMeta = typemeta.Secret
 		// ensure PropagationPolicy
 		return util.ApplyPropagationPolicy(p.Client, p.allClusters(), s)
 	}
@@ -230,7 +231,8 @@ func (p *IstioPlugin) applyPolicyForIstioCustomResource() error {
 
 	resourceSelectors := make([]policyv1alpha1.ResourceSelector, 0)
 	for _, crd := range crds.Items {
-		if !strings.HasSuffix(crd.Name, "istio.io") {
+		// For some resources, they will be created in the subsequent createIstioOperator steps. In order to ensure the idempotency of the installation, some options are skipped here.
+		if !strings.HasSuffix(crd.Name, "istio.io") || crd.Name == iopCRDName {
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: Xieql <xieqianglong@huawei.com>

**What type of PR is this?**


/kind bug


**What this PR does / why we need it**:
1 There is no kind in the return value of Casecret, which will cause an error when checking the type later, so a check is added.
2 After the createIstioOperator step has been performed, reinstalll will add an additional “{install.istio.io/v1alpha1 IstioOperator nil}”, causing the update to fail. Since the crd will be created later, so it is skipped here.

After these fixes, it has been tested that after the istio is forced to exit at any step, the subsequent reinstallation can be installed normally.

**Which issue(s) this PR fixes**:
Fixes #88

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE
```release-note

```

