### PR TITLE
Make install volcano and prometheus idempotent

### DIFF
--- a/pkg/plugin/volcano/plugin.go
+++ b/pkg/plugin/volcano/plugin.go
@@ -18,7 +18,6 @@ package volcano
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"runtime"
 	"strings"
@@ -86,16 +85,16 @@ func (p *Plugin) Execute(cmdArgs, environment []string) error {
 		return nil
 	}
 
-	if _, err := p.HelmClient().Create(resourceList); err != nil {
+	if _, err := p.HelmClient().Update(resourceList, resourceList, false); err != nil {
 		return err
 	}
 
-	if _, err := p.KarmadaClient().PolicyV1alpha1().ClusterPropagationPolicies().Create(context.TODO(), cpp, metav1.CreateOptions{}); err != nil {
-		return err
+	if err := p.UpdateResource(cpp); err != nil {
+		return fmt.Errorf("apply ClusterPropagationPolicy fail, %v", err)
 	}
 
-	if _, err := p.KarmadaClient().PolicyV1alpha1().PropagationPolicies(pp.Namespace).Create(context.TODO(), pp, metav1.CreateOptions{}); err != nil {
-		return err
+	if err := p.UpdateResource(pp); err != nil {
+		return fmt.Errorf("apply PropagationPolicy fail, %v", err)
 	}
 
 	return nil
@@ -105,6 +104,10 @@ func (p *Plugin) generatePolicy(resourceList kube.ResourceList) (
 	*policyv1alpha1.ClusterPropagationPolicy,
 	*policyv1alpha1.PropagationPolicy) {
 	cpp := &policyv1alpha1.ClusterPropagationPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "policy.karmada.io/v1alpha1",
+			Kind:       "ClusterPropagationPolicy",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "volcano",
 		},
@@ -119,6 +122,10 @@ func (p *Plugin) generatePolicy(resourceList kube.ResourceList) (
 	}
 
 	pp := &policyv1alpha1.PropagationPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "policy.karmada.io/v1alpha1",
+			Kind:       "PropagationPolicy",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "volcano",
 			Namespace: volcanoSystemNamespace,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
part of #53 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

It is worth mentioning that，
pkg/plugin/volcano/plugin.go L88.
```
_, err := p.HelmClient().Update(resourceList, resourceList, false)
```
The "false" here cannot be changed to "true".
Otherwise, the following error will appear: 
```
 'execute kurator command failed:  volcano execute error: failed to replace object: Job.batch "volcano-admission-init" is invalid:
  [spec.selector: Required value,
 spec.template.metadata.labels: Invalid value: map[string]string(nil): `selector` does not match template `labels`,
 spec.selector: Invalid value: "null": field is immutable,
 spec.template: Invalid value: core.PodTemplateSpec{[skipped]}: field is immutable]'
```
[here](https://github.com/helm/helm/issues/7168) mentions this issue

**Does this PR introduce a user-facing change?**:

NONE