### PR TITLE
bump to golang 1.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.19.x
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run gen-check
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.19.x
       - name: Install Node
         uses: actions/setup-node@v3
         with:
@@ -50,7 +50,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.19.x
       - name: compile
         run: make build
   test:
@@ -62,6 +62,6 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.19.x
       - name: make test
         run: make test

--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -32,15 +32,12 @@ linters:
     - goimports
     - govet
     # linters default enabled by golangci-lint .
-    - deadcode
     - errcheck
     - gosimple
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     # other linters supported by golangci-lint.
     #- gocyclo
     #- gosec

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kurator.dev/kurator
 
-go 1.17
+go 1.19
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 GOLANGCI_LINT_PKG="github.com/golangci/golangci-lint/cmd/golangci-lint"
-GOLANGCI_LINT_VER="v1.42.1"
+GOLANGCI_LINT_VER="v1.50.1"
 
 cd "${REPO_ROOT}"
 source "hack/util.sh"

--- a/manifests/manifests.go
+++ b/manifests/manifests.go
@@ -21,6 +21,7 @@ import (
 )
 
 // FS embeds the manifests
+//
 //go:embed profiles/* profiles/prom/* profiles/prom-thanos/* profiles/thanos/*
 var FS embed.FS
 

--- a/pkg/generic/base.go
+++ b/pkg/generic/base.go
@@ -17,7 +17,7 @@ limitations under the License.
 package generic
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
@@ -25,7 +25,7 @@ import (
 
 func (g *Options) FlagSet(n string) *flag.FlagSet {
 	f := flag.NewFlagSet(n, flag.ExitOnError)
-	f.SetOutput(ioutil.Discard)
+	f.SetOutput(io.Discard)
 
 	// Set the default Usage to empty
 	f.Usage = func() {


### PR DESCRIPTION
Signed-off-by: hejianpeng <hejianpeng2@huawei.com>

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind feature

**What this PR does / why we need it**:

`make lint` will not failing on local machine with go1.19

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

