### PR TITLE
aws: support vpc.id and vpc.name

### DIFF
--- a/pkg/infra/scope/cluster.go
+++ b/pkg/infra/scope/cluster.go
@@ -43,7 +43,9 @@ type Cluster struct {
 	CredentialSecretRef string
 	Version             string
 	Region              string
+	VpcID               string
 	VpcCIDR             string
+	VpcName             string
 	PodCIDR             []string
 	ServiceCIDR         []string
 	CNIType             string
@@ -85,7 +87,9 @@ func NewCluster(cluster *clusterv1alpha1.Cluster) *Cluster {
 		NamespacedName:    nn,
 		Version:           cluster.Spec.Version,
 		Region:            cluster.Spec.Region,
+		VpcID:             cluster.Spec.Network.VPC.ID,
 		VpcCIDR:           cluster.Spec.Network.VPC.CIDRBlock,
+		VpcName:           cluster.Spec.Network.VPC.Name,
 		PodCIDR:           cluster.Spec.Network.PodCIDRs,
 		ServiceCIDR:       cluster.Spec.Network.ServiceCIDRs,
 		ControlPlane:      NewInstance(cluster.Spec.InfraType, cluster.Spec.Master.MachineConfig),


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind bug

**What this PR does / why we need it**:

support vpc.id and vpc.name

rely on https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3991

**Which issue(s) this PR fixes**:
Fixes #213 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

