### PR TITLE
customcluster: enhance naming

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	k8s.io/api v0.25.4
 	k8s.io/apiextensions-apiserver v0.25.4
 	k8s.io/apimachinery v0.25.4
+	k8s.io/apiserver v0.25.4
 	k8s.io/cli-runtime v0.25.4
 	k8s.io/client-go v0.25.4
 	k8s.io/code-generator v0.25.4
@@ -235,7 +236,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	istio.io/client-go v1.12.0-alpha.5.0.20221109212442-23681e5ef331 // indirect
-	k8s.io/apiserver v0.25.4 // indirect
 	k8s.io/cluster-bootstrap v0.25.4 // indirect
 	k8s.io/gengo v0.0.0-20211129171323-c02415ce4185 // indirect
 	k8s.io/kube-aggregator v0.25.4 // indirect

--- a/pkg/controllers/customcluster_controller.go
+++ b/pkg/controllers/customcluster_controller.go
@@ -73,7 +73,7 @@ const (
 
 	ClusterKind       = "Cluster"
 	CustomClusterKind = "CustomCluster"
-	ManageActionLabel = "manage-action"
+	ManageActionLabel = "customcluster.kurator.dev/action"
 
 	KubesprayCMDPrefix                                     = "ansible-playbook -i inventory/" + ClusterHostsName + " --private-key /root/.ssh/ssh-privatekey "
 	CustomClusterInitAction      customClusterManageAction = "init"

--- a/pkg/controllers/customcluster_controller.go
+++ b/pkg/controllers/customcluster_controller.go
@@ -73,6 +73,7 @@ const (
 
 	ClusterKind       = "Cluster"
 	CustomClusterKind = "CustomCluster"
+	ManageActionLabel = "manage-action"
 
 	KubesprayCMDPrefix                                     = "ansible-playbook -i inventory/" + ClusterHostsName + " --private-key /root/.ssh/ssh-privatekey "
 	CustomClusterInitAction      customClusterManageAction = "init"
@@ -428,19 +429,19 @@ func (r *CustomClusterController) reconcileDelete(ctx context.Context, customClu
 // deleteWorkerPods delete all the manage worker pods, including those for initialization, scaling up, scaling down, and other related tasks.
 func (r *CustomClusterController) deleteWorkerPods(ctx context.Context, customCluster *v1alpha1.CustomCluster) error {
 	// Delete the init worker.
-	if err := r.ensureWorkerPodDeleted(ctx, generateWorkerKey(customCluster, CustomClusterInitAction)); err != nil {
+	if err := r.ensureWorkerPodDeleted(ctx, customCluster, CustomClusterInitAction); err != nil {
 		log.Error(err, "failed to delete init worker", "name", customCluster.Name, "namespace", customCluster.Namespace)
 		return err
 	}
 
 	// Delete the scale up worker.
-	if err := r.ensureWorkerPodDeleted(ctx, generateWorkerKey(customCluster, CustomClusterScaleUpAction)); err != nil {
+	if err := r.ensureWorkerPodDeleted(ctx, customCluster, CustomClusterScaleUpAction); err != nil {
 		log.Error(err, "failed to delete scale up worker", "name", customCluster.Name, "namespace", customCluster.Namespace)
 		return err
 	}
 
 	// Delete the scale down worker.
-	if err := r.ensureWorkerPodDeleted(ctx, generateWorkerKey(customCluster, CustomClusterScaleDownAction)); err != nil {
+	if err := r.ensureWorkerPodDeleted(ctx, customCluster, CustomClusterScaleDownAction); err != nil {
 		log.Error(err, "failed to delete scale down worker", "name", customCluster.Name, "namespace", customCluster.Namespace)
 		return err
 	}

--- a/pkg/controllers/customcluster_helper.go
+++ b/pkg/controllers/customcluster_helper.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/storage/names"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,7 +40,8 @@ import (
 
 // generateClusterManageWorker generate a kubespray manage worker pod from configmap.
 func generateClusterManageWorker(customCluster *v1alpha1.CustomCluster, manageAction customClusterManageAction, manageCMD customClusterManageCMD, hostsName, configName string) *corev1.Pod {
-	podName := customCluster.Name + "-" + string(manageAction)
+	basePodName := customCluster.Name + "-" + string(manageAction)
+	podName := names.SimpleNameGenerator.GenerateName(basePodName + "-")
 	namespace := customCluster.Namespace
 	defaultMode := int32(0o600)
 	kubesprayImage := getKubesprayImage(DefaultKubesprayVersion)
@@ -570,6 +572,5 @@ func (r *CustomClusterController) createKubeConfigSecret(ctx context.Context, na
 }
 
 func getKubeConfigSecretName(customCluster *v1alpha1.CustomCluster) string {
-	// todo: Enhance the robustness of naming.
-	return customCluster.Name
+	return names.SimpleNameGenerator.GenerateName(customCluster.Name + "-kubeconfig-")
 }

--- a/pkg/controllers/customcluster_helper.go
+++ b/pkg/controllers/customcluster_helper.go
@@ -416,7 +416,6 @@ func (r *CustomClusterController) ensureWorkerPodCreated(ctx context.Context, cu
 		return nil, fmt.Errorf("failed to create customCluster manager worker pod: %v", err)
 	}
 	return newWorkerPod, nil
-
 }
 
 // findManageWorkerPod locates the worker pod that has the given manageAction label and input OwnerReferences.

--- a/pkg/controllers/customcluster_helper.go
+++ b/pkg/controllers/customcluster_helper.go
@@ -47,6 +47,7 @@ func generateClusterManageWorker(customCluster *v1alpha1.CustomCluster, manageAc
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      podName,
+			Labels:    map[string]string{ManageActionLabel: string(manageAction)},
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -260,13 +261,6 @@ func (r *CustomClusterController) CreateClusterConfig(ctx context.Context, c *cl
 	return r.CreateConfigMapWithTemplate(ctx, name, namespace, ClusterConfigName, configTemplate)
 }
 
-func generateWorkerKey(customCluster *v1alpha1.CustomCluster, action customClusterManageAction) client.ObjectKey {
-	return client.ObjectKey{
-		Namespace: customCluster.Namespace,
-		Name:      customCluster.Name + "-" + string(action),
-	}
-}
-
 func generateClusterHostsKey(customCluster *v1alpha1.CustomCluster) client.ObjectKey {
 	return client.ObjectKey{
 		Namespace: customCluster.Namespace,
@@ -386,39 +380,64 @@ func (r *CustomClusterController) ensureConfigMapDeleted(ctx context.Context, cm
 }
 
 // ensureWorkerPodDeleted ensures that the worker pod is deleted.
-func (r *CustomClusterController) ensureWorkerPodDeleted(ctx context.Context, workerPodKey client.ObjectKey) error {
-	worker := &corev1.Pod{}
-	errGetWorker := r.Client.Get(ctx, workerPodKey, worker)
-	// errGetWorker can be divided into three situation: isNotFound; not isNotFound; nil.
-	if apierrors.IsNotFound(errGetWorker) {
-		return nil
-	} else if errGetWorker != nil && !apierrors.IsNotFound(errGetWorker) {
-		return fmt.Errorf("failed to get worker pod when it should be deleted: %v", errGetWorker)
-	} else if errGetWorker == nil {
-		if err := r.Client.Delete(ctx, worker); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete cm when it should be deleted: %v", err)
-		}
+func (r *CustomClusterController) ensureWorkerPodDeleted(ctx context.Context, customCluster *v1alpha1.CustomCluster, manageAction customClusterManageAction) error {
+	workerPod, err := r.findManageWorkerPod(ctx, customCluster, manageAction)
+
+	if err != nil {
+		return fmt.Errorf("failed find customCluster manager worker pod: %v", err)
 	}
+	if workerPod == nil {
+		return nil
+	}
+
+	if err := r.Client.Delete(ctx, workerPod); err != nil {
+		return fmt.Errorf("failed to delete workerPod: %v", err)
+	}
+
 	return nil
 }
 
 // ensureWorkerPodCreated ensure that the worker pod is created.
 func (r *CustomClusterController) ensureWorkerPodCreated(ctx context.Context, customCluster *v1alpha1.CustomCluster, manageAction customClusterManageAction, manageCMD customClusterManageCMD, hostName, configName string) (*corev1.Pod, error) {
-	workerPodKey := generateWorkerKey(customCluster, manageAction)
-	workerPod := &corev1.Pod{}
+	workerPod, err := r.findManageWorkerPod(ctx, customCluster, manageAction)
 
-	if err := r.Client.Get(ctx, workerPodKey, workerPod); err != nil {
-		if apierrors.IsNotFound(err) {
-			workerPod = generateClusterManageWorker(customCluster, manageAction, manageCMD, hostName, configName)
-			workerPod.OwnerReferences = []metav1.OwnerReference{generateOwnerRefFromCustomCluster(customCluster)}
-			if err1 := r.Client.Create(ctx, workerPod); err1 != nil {
-				return nil, fmt.Errorf("failed to create customCluster manager worker pod: %v", err1)
-			}
-			return workerPod, nil
-		}
-		return nil, fmt.Errorf("failed to get worker pod: %v", err)
+	if err != nil {
+		return nil, fmt.Errorf("failed find customCluster manager worker pod: %v", err)
 	}
-	return workerPod, nil
+	if workerPod != nil {
+		return workerPod, nil
+	}
+
+	newWorkerPod := generateClusterManageWorker(customCluster, manageAction, manageCMD, hostName, configName)
+	newWorkerPod.OwnerReferences = []metav1.OwnerReference{generateOwnerRefFromCustomCluster(customCluster)}
+	if err := r.Client.Create(ctx, newWorkerPod); err != nil {
+		return nil, fmt.Errorf("failed to create customCluster manager worker pod: %v", err)
+	}
+	return newWorkerPod, nil
+
+}
+
+// findManageWorkerPod locates the worker pod that has the given manageAction label and input OwnerReferences.
+func (r *CustomClusterController) findManageWorkerPod(ctx context.Context, customCluster *v1alpha1.CustomCluster, manageAction customClusterManageAction) (*corev1.Pod, error) {
+	labelSelector := client.MatchingLabels{ManageActionLabel: string(manageAction)}
+	PodList := &corev1.PodList{}
+
+	errGetWorker := r.Client.List(ctx, PodList, labelSelector)
+
+	if errGetWorker != nil && !apierrors.IsNotFound(errGetWorker) {
+		return nil, fmt.Errorf("failed to get worker pod when it should be deleted: %v", errGetWorker)
+	}
+
+	if errGetWorker == nil {
+		// find the pod with an ownerRef that references this customCluster.
+		for _, pod := range PodList.Items {
+			// the current customCluster's worker has only one ownerRef.
+			if pod.OwnerReferences[0].UID == customCluster.UID {
+				return &pod, nil
+			}
+		}
+	}
+	return nil, nil
 }
 
 // getKubesprayImage take in kubesprayVersion return the kubespray image url of this version.

--- a/pkg/controllers/customcluster_scale.go
+++ b/pkg/controllers/customcluster_scale.go
@@ -77,8 +77,8 @@ func (r *CustomClusterController) reconcileScaleUp(ctx context.Context, customCl
 		}
 
 		// Delete the scaleUp worker.
-		if err := r.ensureWorkerPodDeleted(ctx, generateWorkerKey(customCluster, CustomClusterScaleUpAction)); err != nil {
-			log.Error(err, "failed to delete scaleUp worker pod", "worker", generateWorkerKey(customCluster, CustomClusterScaleUpAction))
+		if err := r.ensureWorkerPodDeleted(ctx, customCluster, CustomClusterScaleUpAction); err != nil {
+			log.Error(err, "failed to delete scaleUp worker pod", "customCluster", customCluster.Name)
 			return ctrl.Result{}, err
 		}
 		conditions.MarkTrue(customCluster, v1alpha1.ScaledUpCondition)
@@ -129,8 +129,8 @@ func (r *CustomClusterController) reconcileScaleDown(ctx context.Context, custom
 		customCluster.Status.Phase = v1alpha1.ProvisionedPhase
 
 		// Delete the scaleDown worker
-		if err := r.ensureWorkerPodDeleted(ctx, generateWorkerKey(customCluster, CustomClusterScaleDownAction)); err != nil {
-			log.Error(err, "failed to delete scaleDown worker pod", "worker", generateWorkerKey(customCluster, CustomClusterScaleDownAction))
+		if err := r.ensureWorkerPodDeleted(ctx, customCluster, CustomClusterScaleDownAction); err != nil {
+			log.Error(err, "failed to delete scaleDown worker pod", "worker", customCluster.Name)
 			return ctrl.Result{}, err
 		}
 		conditions.MarkTrue(customCluster, v1alpha1.ScaledDownCondition)

--- a/pkg/controllers/customcluster_upgrade.go
+++ b/pkg/controllers/customcluster_upgrade.go
@@ -62,8 +62,8 @@ func (r *CustomClusterController) reconcileUpgrade(ctx context.Context, customCl
 		customCluster.Status.Phase = v1alpha1.ProvisionedPhase
 
 		// Delete the upgrading worker.
-		if err := r.ensureWorkerPodDeleted(ctx, generateWorkerKey(customCluster, CustomClusterUpgradeAction)); err != nil {
-			log.Error(err, "failed to delete upgrade worker pod", "worker", generateWorkerKey(customCluster, CustomClusterUpgradeAction))
+		if err := r.ensureWorkerPodDeleted(ctx, customCluster, CustomClusterUpgradeAction); err != nil {
+			log.Error(err, "failed to delete upgrade worker pod", "customCluster", customCluster.Name)
 			return ctrl.Result{}, err
 		}
 		conditions.MarkTrue(customCluster, v1alpha1.UpgradeCondition)


### PR DESCRIPTION
**What type of PR is this?**

<!--

/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Enhance naming of workerpod and kubeconfig secret 

Besides，as modifying the naming of the worker pod would impact ensureWorkerDelete and ensureWorkerCreated, these two functions were also refactored.

In the **original design**, a specific worker pod was located using the `customCluster` name and a `manage action` in the name. However, there were some issues:

- A random number was appended to the name, making it unpredictable.
- It was not possible to locate the desired pod using a specific name as before.

To address these issues, the following changes have been made:

- **Labels** are now used to identify the specific action that was previously identified by  `manage action`  in name.
- **ownerRefs** are used to identify the specific `customCluster`.