### PR TITLE
chore: use seperated kubeconfig file for different cluster

### DIFF
--- a/docs/content/en/docs/Integrations/karmada.md
+++ b/docs/content/en/docs/Integrations/karmada.md
@@ -46,8 +46,14 @@ kurator install karmada --set karmada-data=/etc/Karmada-test --set port=32222 --
 
 ```bash
 kurator join karmada member1 \
-    --cluster-kubeconfig=/root/.kube/kurator-members.config \
+    --cluster-kubeconfig=/root/.kube/kurator-member1.config \
     --cluster-context=kurator-member1
+```
+
+```bash
+kurator join karmada member2 \
+    --cluster-kubeconfig=/root/.kube/kurator-member2.config \
+    --cluster-context=kurator-member2
 ```
 
 Show members of karmada 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

