### PR TITLE
fleet:fix cluster copy bug

### DIFF
--- a/pkg/fleet-manager/clusters.go
+++ b/pkg/fleet-manager/clusters.go
@@ -140,12 +140,13 @@ func (f *FleetManager) reconcileClusters(ctx context.Context, fleet *fleetapi.Fl
 	var labeledCluster []ClusterInterface
 
 	for _, cluster := range clusterList.Items {
-		labeledCluster = append(labeledCluster, &cluster)
+		clusterCopy := cluster.DeepCopy()
+		labeledCluster = append(labeledCluster, clusterCopy)
 	}
 
 	for _, attachedCluster := range attachedClusterList.Items {
-		log.Info("a attachedCluster added ", "attachedCluster", attachedCluster.Name)
-		labeledCluster = append(labeledCluster, &attachedCluster)
+		attachedClusterCopy := attachedCluster.DeepCopy()
+		labeledCluster = append(labeledCluster, attachedClusterCopy)
 	}
 
 	for _, cluster := range labeledCluster {

--- a/pkg/fleet-manager/clusters.go
+++ b/pkg/fleet-manager/clusters.go
@@ -140,13 +140,13 @@ func (f *FleetManager) reconcileClusters(ctx context.Context, fleet *fleetapi.Fl
 	var labeledCluster []ClusterInterface
 
 	for _, cluster := range clusterList.Items {
-		clusterCopy := cluster.DeepCopy()
-		labeledCluster = append(labeledCluster, clusterCopy)
+		tmpCluster := cluster
+		labeledCluster = append(labeledCluster, &tmpCluster)
 	}
 
 	for _, attachedCluster := range attachedClusterList.Items {
-		attachedClusterCopy := attachedCluster.DeepCopy()
-		labeledCluster = append(labeledCluster, attachedClusterCopy)
+		tmpAttachedCluster := attachedCluster
+		labeledCluster = append(labeledCluster, &tmpAttachedCluster)
 	}
 
 	for _, cluster := range labeledCluster {


### PR DESCRIPTION
**What type of PR is this?**


/kind bug


**What this PR does / why we need it**:

This bug causes：  when deleting clusters from the fleet，only the label of the last cluster can be deleted



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

