### PR TITLE
customcluster: support kubeversion to v1.26.5

### DIFF
--- a/docs/content/en/docs/cluster-operator/vms-cluster-lifecycle.md
+++ b/docs/content/en/docs/cluster-operator/vms-cluster-lifecycle.md
@@ -389,7 +389,7 @@ spec:
       maxSurge: 1
     type: RollingUpdate
   # edit the version to desired upgrading version
-  version: v1.24.6
+  version: v1.26.5
 status:
   conditions:
   ...

--- a/examples/infra/customcluster/cc-kcp.yaml
+++ b/examples/infra/customcluster/cc-kcp.yaml
@@ -19,4 +19,4 @@ spec:
       kind: customMachine
       name: cc-custommachine
       namespace: default
-  version: v1.24.6
+  version: v1.26.5

--- a/pkg/cluster-operator/customcluster_helper.go
+++ b/pkg/cluster-operator/customcluster_helper.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
@@ -39,12 +40,11 @@ import (
 )
 
 // generateClusterManageWorker generate a kubespray manage worker pod from configmap.
-func generateClusterManageWorker(customCluster *v1alpha1.CustomCluster, manageAction customClusterManageAction, manageCMD customClusterManageCMD, hostsName, configName string) *corev1.Pod {
+func generateClusterManageWorker(customCluster *v1alpha1.CustomCluster, manageAction customClusterManageAction, manageCMD customClusterManageCMD, hostsName, configName, kubesprayImage string) *corev1.Pod {
 	basePodName := customCluster.Name + "-" + string(manageAction)
 	podName := names.SimpleNameGenerator.GenerateName(basePodName + "-")
 	namespace := customCluster.Namespace
 	defaultMode := int32(0o600)
-	kubesprayImage := getKubesprayImage(DefaultKubesprayVersion)
 	managerWorker := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -400,7 +400,7 @@ func (r *CustomClusterController) ensureWorkerPodDeleted(ctx context.Context, cu
 }
 
 // ensureWorkerPodCreated ensure that the worker pod is created.
-func (r *CustomClusterController) ensureWorkerPodCreated(ctx context.Context, customCluster *v1alpha1.CustomCluster, manageAction customClusterManageAction, manageCMD customClusterManageCMD, hostName, configName string) (*corev1.Pod, error) {
+func (r *CustomClusterController) ensureWorkerPodCreated(ctx context.Context, customCluster *v1alpha1.CustomCluster, manageAction customClusterManageAction, manageCMD customClusterManageCMD, hostName, configName, kubeVersion string) (*corev1.Pod, error) {
 	workerPod, err := r.findManageWorkerPod(ctx, customCluster, manageAction)
 
 	if err != nil {
@@ -410,7 +410,12 @@ func (r *CustomClusterController) ensureWorkerPodCreated(ctx context.Context, cu
 		return workerPod, nil
 	}
 
-	newWorkerPod := generateClusterManageWorker(customCluster, manageAction, manageCMD, hostName, configName)
+	kubesprayImage, err := getKubesprayImage(kubeVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	newWorkerPod := generateClusterManageWorker(customCluster, manageAction, manageCMD, hostName, configName, kubesprayImage)
 	newWorkerPod.OwnerReferences = []metav1.OwnerReference{generateOwnerRefFromCustomCluster(customCluster)}
 	if err := r.Client.Create(ctx, newWorkerPod); err != nil {
 		return nil, fmt.Errorf("failed to create customCluster manager worker pod: %v", err)
@@ -441,10 +446,34 @@ func (r *CustomClusterController) findManageWorkerPod(ctx context.Context, custo
 	return nil, nil
 }
 
-// getKubesprayImage take in kubesprayVersion return the kubespray image url of this version.
-func getKubesprayImage(kubesprayVersion string) string {
+// getKubesprayImage takes a Kubernetes version string (in the format "vX.Y.Z")
+// and returns the corresponding Kubespray image URL for that version.
+// The function supports Kubernetes versions from 1.22.0 to 1.26.5.
+// Kubespray v2.20.0 supports Kubernetes versions from 1.22.0 to 1.24.6,
+// while Kubespray v2.22.1 supports Kubernetes versions from 1.24.0 to 1.26.5.
+// This function returns one of these two Kubespray versions based on the input Kubernetes version.
+func getKubesprayImage(kubeVersion string) (string, error) {
+	var kubesprayVersion string
+	kubeVersion = strings.TrimPrefix(kubeVersion, "v")
+	targetVersion, err := semver.NewVersion(kubeVersion)
+	if err != nil {
+		return "", err
+	}
+
+	midVersion, err := semver.NewVersion("1.24.0")
+	if err != nil {
+		return "", err
+	}
+
+	// Determine the Kubespray version based on the Kubernetes version.
+	if targetVersion.Compare(*midVersion) >= 0 {
+		kubesprayVersion = "v2.22.1"
+	} else {
+		kubesprayVersion = "v2.20.0"
+	}
+
 	imagePath := "quay.io/kubespray/kubespray:" + kubesprayVersion
-	return imagePath
+	return imagePath, nil
 }
 
 // hasProvisionClusterInfo is used to determine if the current phase is valid for retrieving ProvisionClusterInfo.

--- a/pkg/cluster-operator/customcluster_helper.go
+++ b/pkg/cluster-operator/customcluster_helper.go
@@ -457,7 +457,7 @@ func getKubesprayImage(ctx context.Context, kubeVersion string) string {
 	kubeVersion = strings.TrimPrefix(kubeVersion, "v")
 
 	targetVersion, err := semver.NewVersion(kubeVersion)
-	// should not happen
+	// should not happen, if we have validation on kubeVersion
 	if err != nil {
 		log.Error(err, "unexpected kube version", "targetVersion", targetVersion)
 		return ""

--- a/pkg/cluster-operator/customcluster_helper.go
+++ b/pkg/cluster-operator/customcluster_helper.go
@@ -453,7 +453,9 @@ func (r *CustomClusterController) findManageWorkerPod(ctx context.Context, custo
 func getKubesprayImage(ctx context.Context, kubeVersion string) string {
 	log := ctrl.LoggerFrom(ctx)
 	var kubesprayVersion string
+
 	kubeVersion = strings.TrimPrefix(kubeVersion, "v")
+
 	targetVersion, err := semver.NewVersion(kubeVersion)
 	// should not happen
 	if err != nil {
@@ -461,12 +463,7 @@ func getKubesprayImage(ctx context.Context, kubeVersion string) string {
 		return ""
 	}
 
-	midVersion, err := semver.NewVersion("1.24.0")
-	// should not happen
-	if err != nil {
-		log.Error(err, "unexpected kube version", "midVersion", midVersion)
-		return ""
-	}
+	midVersion, _ := semver.NewVersion("1.24.0")
 
 	// Determine the Kubespray version based on the Kubernetes version.
 	if targetVersion.Compare(*midVersion) >= 0 {

--- a/pkg/cluster-operator/customcluster_upgrade.go
+++ b/pkg/cluster-operator/customcluster_upgrade.go
@@ -36,7 +36,7 @@ func (r *CustomClusterController) reconcileUpgrade(ctx context.Context, customCl
 
 	cmd := generateUpgradeManageCMD(targetVersion)
 	// Checks whether the worker node for upgrading already exists. If it does not exist, then create it.
-	workerPod, err1 := r.ensureWorkerPodCreated(ctx, customCluster, CustomClusterUpgradeAction, cmd, generateClusterHostsName(customCluster), generateClusterConfigName(customCluster))
+	workerPod, err1 := r.ensureWorkerPodCreated(ctx, customCluster, CustomClusterUpgradeAction, cmd, generateClusterHostsName(customCluster), generateClusterConfigName(customCluster), targetVersion)
 	if err1 != nil {
 		conditions.MarkFalse(customCluster, v1alpha1.UpgradeCondition, v1alpha1.UpgradeWorkerCreateFailed,
 			clusterv1.ConditionSeverityWarning, "upgrade worker is failed to create %s/%s.", customCluster.Namespace, customCluster.Name)


### PR DESCRIPTION
**What type of PR is this?**


/kind feature


**What this PR does / why we need it**:

The previously supported kubeversion ranged from 'v1.22.0 - v1.24.6', and it has now been extended to include 'v1.22.0 - v1.26.5'.


part of #218 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

