### PR TITLE
[customcluster] fix configContent is nil bug

### DIFF
--- a/pkg/cluster-operator/customcluster_helper.go
+++ b/pkg/cluster-operator/customcluster_helper.go
@@ -154,18 +154,22 @@ type ConfigTemplateContent struct {
 func GetConfigContent(c *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane, cc *v1alpha1.CustomCluster) *ConfigTemplateContent {
 	// Add kubespray init config here
 	configContent := &ConfigTemplateContent{
-		PodCIDR:                c.Spec.ClusterNetwork.Pods.CIDRBlocks[0],
-		ServiceCIDR:            c.Spec.ClusterNetwork.Services.CIDRBlocks[0],
-		KubeVersion:            kcp.Spec.Version,
-		CNIType:                cc.Spec.CNI.Type,
-		ControlPlaneAddress:    cc.Spec.ControlPlaneConfig.Address,
-		ControlPlaneCertSANs:   strings.Join(cc.Spec.ControlPlaneConfig.CertSANs, ","),
-		ClusterName:            kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ClusterName,
-		DnsDomain:              c.Spec.ClusterNetwork.ServiceDomain,
-		KubeImageRepo:          kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ImageRepository,
-		FeatureGates:           kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.FeatureGates,
-		LoadBalancerDomainName: cc.Spec.ControlPlaneConfig.LoadBalancerDomainName,
+		PodCIDR:       c.Spec.ClusterNetwork.Pods.CIDRBlocks[0],
+		ServiceCIDR:   c.Spec.ClusterNetwork.Services.CIDRBlocks[0],
+		KubeVersion:   kcp.Spec.Version,
+		CNIType:       cc.Spec.CNI.Type,
+		ClusterName:   kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ClusterName,
+		DnsDomain:     c.Spec.ClusterNetwork.ServiceDomain,
+		KubeImageRepo: kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ImageRepository,
+		FeatureGates:  kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.FeatureGates,
 	}
+
+	if cc.Spec.ControlPlaneConfig != nil {
+		configContent.ControlPlaneCertSANs = strings.Join(cc.Spec.ControlPlaneConfig.CertSANs, ",")
+		configContent.ControlPlaneAddress = cc.Spec.ControlPlaneConfig.Address
+		configContent.LoadBalancerDomainName = cc.Spec.ControlPlaneConfig.LoadBalancerDomainName
+	}
+
 	return configContent
 }
 


### PR DESCRIPTION
**What type of PR is this?**


/kind bug

**What this PR does / why we need it**:

If the `ControlPlaneConfig` parameter is not set, a null pointer exception will occur. Therefore, it is necessary to check its existence in the code.

Other variables were also checked in a similar manner. However, since they are mandatory and guaranteed to be non-nil during the admission phase, no changes were required.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix configContent in customcluster is nil bug
```

