### PR TITLE
Cluster controller revise

### DIFF
--- a/pkg/cluster-operator/cluster_controller.go
+++ b/pkg/cluster-operator/cluster_controller.go
@@ -160,7 +160,7 @@ func (r *ClusterController) reconcileDelete(ctx context.Context, cluster *cluste
 	// CAPI Cluster is deleted, do the rest
 
 	if err := provider.Clean(ctx); err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to delete AWS Cluster %s/%s", cluster.Namespace, cluster.Name)
+		return ctrl.Result{}, errors.Wrapf(err, "failed to delete %s Cluster %s/%s", scope.InfraType, cluster.Namespace, cluster.Name)
 	}
 
 	// clean up ClusterResourceSet

--- a/pkg/cluster-operator/cluster_controller.go
+++ b/pkg/cluster-operator/cluster_controller.go
@@ -267,7 +267,7 @@ func (r *ClusterController) reconcile(ctx context.Context, cluster *clusterv1alp
 	if err := provider.Reconcile(ctx); err != nil {
 		conditions.MarkFalse(cluster, clusterv1alpha1.InfrastructureReadyCondition, clusterv1alpha1.InfrastructureProvisionFailedReason,
 			capiv1.ConditionSeverityError, err.Error())
-		return ctrl.Result{RequeueAfter: r.RequeueAfter}, errors.Wrapf(err, "failed to reconcile AWS Cluster %s/%s", cluster.Namespace, cluster.Name)
+		return ctrl.Result{RequeueAfter: r.RequeueAfter}, errors.Wrapf(err, "failed to reconcile %s Cluster %s/%s", scope.InfraType, cluster.Namespace, cluster.Name)
 	}
 
 	// check Cluster status

--- a/pkg/cluster-operator/customcluster_controller.go
+++ b/pkg/cluster-operator/customcluster_controller.go
@@ -512,7 +512,7 @@ func (r *CustomClusterController) ensureFinalizerAndOwnerRef(ctx context.Context
 func (r *CustomClusterController) WorkerToCustomClusterMapFunc(o client.Object) []ctrl.Request {
 	c, ok := o.(*corev1.Pod)
 	if !ok {
-		panic(fmt.Sprintf("Expected a Cluster but got a %T", o))
+		panic(fmt.Sprintf("Expected a pod but got a %T", o))
 	}
 	for _, owner := range c.GetOwnerReferences() {
 		if owner.Kind == CustomClusterKind {

--- a/pkg/cluster-operator/customcluster_controller.go
+++ b/pkg/cluster-operator/customcluster_controller.go
@@ -417,6 +417,8 @@ func (r *CustomClusterController) reconcileDelete(ctx context.Context, customClu
 
 // deleteWorkerPods delete all the manage worker pods, including those for initialization, scaling up, scaling down, and other related tasks.
 func (r *CustomClusterController) deleteWorkerPods(ctx context.Context, customCluster *v1alpha1.CustomCluster) error {
+	log := ctrl.LoggerFrom(ctx)
+
 	// Delete the init worker.
 	if err := r.ensureWorkerPodDeleted(ctx, customCluster, CustomClusterInitAction); err != nil {
 		log.Error(err, "failed to delete init worker", "name", customCluster.Name, "namespace", customCluster.Namespace)


### PR DESCRIPTION
./customcluster_controller.go:423:3: undefined: log
./customcluster_controller.go:429:3: undefined: log
./customcluster_controller.go:435:3: undefined: log

[undefiend log in function deleteWorkerPods]


