### PR TITLE
doc: add output flag for curl release package

### DIFF
--- a/docs/content/en/docs/setup/insatll-kurator.md
+++ b/docs/content/en/docs/setup/insatll-kurator.md
@@ -23,7 +23,7 @@ And then move the executable binary to your PATH.
 Go to [Kurator release](https://github.com/kurator-dev/kurator/releases) page to download the release package for your OS and extract.
 
 ```console
-curl -L https://github.com/kurator-dev/kurator/releases/download/v{{< kurator-version >}}/kurator-{{< kurator-version >}}-linux-amd64.tar.gz
+curl -LO https://github.com/kurator-dev/kurator/releases/download/v{{< kurator-version >}}/kurator-{{< kurator-version >}}-linux-amd64.tar.gz
 tar -zxvf kurator-{{< kurator-version >}}-linux-amd64.tar.gz
 ```
 

--- a/docs/content/en/docs/setup/install-cluster-operator.md
+++ b/docs/content/en/docs/setup/install-cluster-operator.md
@@ -29,7 +29,7 @@ cd out/charts/
 Go to [Kurator release](https://github.com/kurator-dev/kurator/releases) page to download the release package for your OS and extract.
 
 ```bash
-curl -L https://github.com/kurator-dev/kurator/releases/download/v{{< kurator-version >}}/cluster-operator-{{< kurator-version >}}.tgz
+curl -LO https://github.com/kurator-dev/kurator/releases/download/v{{< kurator-version >}}/cluster-operator-{{< kurator-version >}}.tgz
 ```
 
 {{< boilerplate install-cluster-operator >}}

--- a/docs/content/en/docs/setup/install-fleet-manager.md
+++ b/docs/content/en/docs/setup/install-fleet-manager.md
@@ -52,7 +52,7 @@ cd out/charts/
 Go to [Kurator release](https://github.com/kurator-dev/kurator/releases) page to download the release package for your OS and extract.
 
 ```bash
-curl -L https://github.com/kurator-dev/kurator/releases/download/v{{< kurator-version >}}/fleet-manager-{{< kurator-version >}}.tgz
+curl -LO https://github.com/kurator-dev/kurator/releases/download/v{{< kurator-version >}}/fleet-manager-{{< kurator-version >}}.tgz
 ```
 
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:

current commands run failed in my env:

```
$ curl -L https://github.com/kurator-dev/kurator/releases/download/v0.4.0/kurator-0.4.0-linux-amd64.tar.gz
Warning: Binary output can mess up your terminal. Use "--output -" to tell 
Warning: curl to output it to your terminal anyway, or consider "--output 
Warning: <FILE>" to save to a file.
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
doc: add output flag for curl release package
```

