### PR TITLE
fleet: Refactor for broader usage by decoupling from FleetManager

### DIFF
--- a/pkg/fleet-manager/clusters.go
+++ b/pkg/fleet-manager/clusters.go
@@ -70,7 +70,7 @@ func (f *FleetManager) reconcileClusters(ctx context.Context, fleet *fleetapi.Fl
 	for _, cluster := range fleet.Spec.Clusters {
 		// cluster namespace can be not set, always use fleet namespace as a fleet can only include clusters in the same namespace.
 		clusterKey := types.NamespacedName{Name: cluster.Name, Namespace: fleet.Namespace}
-		currentCluster, err := f.getFleetClusterInterface(ctx, cluster.Kind, clusterKey)
+		currentCluster, err := getFleetClusterInterface(ctx, f.Client, cluster.Kind, clusterKey)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				log.Error(err, "unable to fetch cluster", "cluster", clusterKey, "kind", cluster.Kind)
@@ -190,7 +190,7 @@ func (f *FleetManager) reconcileClustersOnDelete(ctx context.Context, fleet *fle
 	for _, cluster := range fleet.Spec.Clusters {
 		// cluster namespace can be not set, always use fleet namespace as a fleet can only include clusters in the same namespace.
 		clusterKey := types.NamespacedName{Name: cluster.Name, Namespace: fleet.Namespace}
-		currentCluster, err := f.getFleetClusterInterface(ctx, cluster.Kind, clusterKey)
+		currentCluster, err := getFleetClusterInterface(ctx, f.Client, cluster.Kind, clusterKey)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				log.Error(err, "unable to fetch cluster", "cluster", clusterKey)

--- a/pkg/fleet-manager/fleet.go
+++ b/pkg/fleet-manager/fleet.go
@@ -166,7 +166,7 @@ func (f *FleetManager) reconcile(ctx context.Context, fleet *fleetapi.Fleet) (ct
 		return res, err
 	}
 
-	fleetClusters, err := f.buildFleetClusters(ctx, fleet)
+	fleetClusters, err := buildFleetClusters(ctx, f.Client, fleet)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to build cluster clients: %w", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
The other manager(backupManager) also need this function `buildFleetClusters` to get clusters info from `Fleet` API, so I refactor it.

Refactor FleetManager methods for broader usage

- Decoupled methods from the FleetManager struct.
- Made functions more generic by accepting client.Client as a parameter.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

