### PR TITLE
fleet: implement buckup plugin

### DIFF
--- a/docs/content/en/references/fleet_v1alpha1_types.html
+++ b/docs/content/en/references/fleet_v1alpha1_types.html
@@ -221,11 +221,17 @@ string
 </em>
 </td>
 <td>
-<p>SecretName represents the name of the secret containing the object store credentials.
-To access the backup storage location, the secret must include the following keys:</p>
+<p>The structure of the secret varies depending on the object storage provider:</p>
 <ul>
-<li><code>access-key</code>: The access-key/account/username for object storage authentication.</li>
-<li><code>secret-key</code>: The secret-key/password for object storage authentication.</li>
+<li><p>For AWS S3, Minio or Huawei Cloud, the secret should contain the following keys:</p>
+<ul>
+<li><code>access-key</code>: The access key for S3 authentication.</li>
+<li><code>secret-key</code>: The secret key for S3 authentication.</li>
+</ul></li>
+<li><p>For GCP, the secret should be created according to the official GCP documentation.
+see <a href="https://github.com/vmware-tanzu/velero-plugin-for-gcp/blob/main/README.md">https://github.com/vmware-tanzu/velero-plugin-for-gcp/blob/main/README.md</a></p></li>
+<li><p>For Azure, the secret should be created according to the official Azure documentation.
+see <a href="https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/main/README.md">https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/main/README.md</a></p></li>
 </ul>
 </td>
 </tr>
@@ -268,7 +274,7 @@ string
 </em>
 </td>
 <td>
-<p>Provider specifies the storage provider type (e.g., aws, gcp, azure).</p>
+<p>Provider specifies the storage provider type (e.g., aws, huaweicloud, gcp, azure).</p>
 </td>
 </tr>
 <tr>
@@ -290,6 +296,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Region specifies the region of the storage.</p>
 </td>
 </tr>
@@ -301,7 +308,23 @@ map[string]string
 </em>
 </td>
 <td>
-<p>Config is a map for additional provider-specific configurations.</p>
+<em>(Optional)</em>
+<p>Config is a map for additional provider-specific configurations.
+#  region:
+#  s3ForcePathStyle:
+#  s3Url:
+#  kmsKeyId:
+#  resourceGroup:
+#  The ID of the subscription containing the storage account, if different from the cluster’s subscription. (Azure only)
+#  subscriptionId:
+#  storageAccount:
+#  publicUrl:
+#  Name of the GCP service account to use for this backup storage location. Specify the
+#  service account here if you want to use workload identity instead of providing the key file.(GCP only)
+#  serviceAccount:
+#  Option to skip certificate validation or not if insecureSkipTLSVerify is set to be true, the client side should set the
+#  flag. For Velero client Command like velero backup describe, velero backup logs needs to add the flag &ndash;insecure-skip-tls-verify
+#  insecureSkipTLSVerify:</p>
 </td>
 </tr>
 </tbody>

--- a/manifests/charts/fleet-manager/crds/fleet.kurator.dev_fleet.yaml
+++ b/manifests/charts/fleet-manager/crds/fleet.kurator.dev_fleet.yaml
@@ -154,8 +154,22 @@ spec:
                               config:
                                 additionalProperties:
                                   type: string
-                                description: Config is a map for additional provider-specific
-                                  configurations.
+                                description: 'Config is a map for additional provider-specific
+                                  configurations. #  region: #  s3ForcePathStyle:
+                                  #  s3Url: #  kmsKeyId: #  resourceGroup: #  The
+                                  ID of the subscription containing the storage account,
+                                  if different from the cluster’s subscription. (Azure
+                                  only) #  subscriptionId: #  storageAccount: #  publicUrl:
+                                  #  Name of the GCP service account to use for this
+                                  backup storage location. Specify the #  service
+                                  account here if you want to use workload identity
+                                  instead of providing the key file.(GCP only) #  serviceAccount:
+                                  #  Option to skip certificate validation or not
+                                  if insecureSkipTLSVerify is set to be true, the
+                                  client side should set the #  flag. For Velero client
+                                  Command like velero backup describe, velero backup
+                                  logs needs to add the flag --insecure-skip-tls-verify
+                                  #  insecureSkipTLSVerify:'
                                 type: object
                               endpoint:
                                 description: Endpoint provides the endpoint URL for
@@ -163,7 +177,7 @@ spec:
                                 type: string
                               provider:
                                 description: Provider specifies the storage provider
-                                  type (e.g., aws, gcp, azure).
+                                  type (e.g., aws, huaweicloud, gcp, azure).
                                 type: string
                               region:
                                 description: Region specifies the region of the storage.
@@ -172,15 +186,17 @@ spec:
                             - bucket
                             - endpoint
                             - provider
-                            - region
                             type: object
                           secretName:
-                            description: "SecretName represents the name of the secret
-                              containing the object store credentials. To access the
-                              backup storage location, the secret must include the
-                              following keys: \n - `access-key`: The access-key/account/username
-                              for object storage authentication. - `secret-key`: The
-                              secret-key/password for object storage authentication."
+                            description: "The structure of the secret varies depending
+                              on the object storage provider: \n - For AWS S3, Minio
+                              or Huawei Cloud, the secret should contain the following
+                              keys: - `access-key`: The access key for S3 authentication.
+                              - `secret-key`: The secret key for S3 authentication.
+                              \n - For GCP, the secret should be created according
+                              to the official GCP documentation. see https://github.com/vmware-tanzu/velero-plugin-for-gcp/blob/main/README.md
+                              \n - For Azure, the secret should be created according
+                              to the official Azure documentation. see https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/main/README.md"
                             type: string
                         required:
                         - location

--- a/pkg/apis/fleet/v1alpha1/types.go
+++ b/pkg/apis/fleet/v1alpha1/types.go
@@ -283,12 +283,18 @@ type BackupStorage struct {
 	// Location specifies where the backup data will be stored.
 	Location BackupStorageLocation `json:"location"`
 
-	// SecretName represents the name of the secret containing the object store credentials.
-	// To access the backup storage location, the secret must include the following keys:
+	// The structure of the secret varies depending on the object storage provider:
 	//
-	// - `access-key`: The access-key/account/username for object storage authentication.
-	// - `secret-key`: The secret-key/password for object storage authentication.
-	// 
+	// - For AWS S3, Minio or Huawei Cloud, the secret should contain the following keys:
+	//   - `access-key`: The access key for S3 authentication.
+	//   - `secret-key`: The secret key for S3 authentication.
+	//
+	// - For GCP, the secret should be created according to the official GCP documentation.
+	//   see https://github.com/vmware-tanzu/velero-plugin-for-gcp/blob/main/README.md
+	//
+	// - For Azure, the secret should be created according to the official Azure documentation.
+	//   see https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/blob/main/README.md
+	//
 	// +required
 	SecretName string `json:"secretName"`
 }
@@ -296,13 +302,30 @@ type BackupStorage struct {
 type BackupStorageLocation struct {
 	// Bucket specifies the storage bucket name.
 	Bucket string `json:"bucket"`
-	// Provider specifies the storage provider type (e.g., aws, gcp, azure).
+	// Provider specifies the storage provider type (e.g., aws, huaweicloud, gcp, azure).
 	Provider string `json:"provider"`
 	// Endpoint provides the endpoint URL for the storage.
 	Endpoint string `json:"endpoint"`
 	// Region specifies the region of the storage.
-	Region string `json:"region"`
+	// +optional
+	Region string `json:"region,omitempty"`
 	// Config is a map for additional provider-specific configurations.
+	// TODO: enable Config, here is what user can set:
+	//    #  region:
+	//    #  s3ForcePathStyle:
+	//    #  s3Url:
+	//    #  kmsKeyId:
+	//    #  resourceGroup:
+	//    #  The ID of the subscription containing the storage account, if different from the cluster’s subscription. (Azure only)
+	//    #  subscriptionId:
+	//    #  storageAccount:
+	//    #  publicUrl:
+	//    #  Name of the GCP service account to use for this backup storage location. Specify the
+	//    #  service account here if you want to use workload identity instead of providing the key file.(GCP only)
+	//    #  serviceAccount:
+	//    #  Option to skip certificate validation or not if insecureSkipTLSVerify is set to be true, the client side should set the
+	//    #  flag. For Velero client Command like velero backup describe, velero backup logs needs to add the flag --insecure-skip-tls-verify
+	//    #  insecureSkipTLSVerify:
 	Config map[string]string `json:"config,omitempty"`
 }
 

--- a/pkg/apis/fleet/v1alpha1/types.go
+++ b/pkg/apis/fleet/v1alpha1/types.go
@@ -310,7 +310,6 @@ type BackupStorageLocation struct {
 	// +optional
 	Region string `json:"region,omitempty"`
 	// Config is a map for additional provider-specific configurations.
-	// TODO: enable Config, here is what user can set:
 	//    #  region:
 	//    #  s3ForcePathStyle:
 	//    #  s3Url:
@@ -326,6 +325,7 @@ type BackupStorageLocation struct {
 	//    #  Option to skip certificate validation or not if insecureSkipTLSVerify is set to be true, the client side should set the
 	//    #  flag. For Velero client Command like velero backup describe, velero backup logs needs to add the flag --insecure-skip-tls-verify
 	//    #  insecureSkipTLSVerify:
+	// +optional
 	Config map[string]string `json:"config,omitempty"`
 }
 

--- a/pkg/fleet-manager/fleet.go
+++ b/pkg/fleet-manager/fleet.go
@@ -42,10 +42,10 @@ import (
 const (
 	FleetKind      = "Fleet"
 	FleetFinalizer = "fleet.kurator.dev"
-)
 
-const RequeueAfter = 5 * time.Second
-const FleetLabel = "fleet.kurator.dev/fleet-name"
+	RequeueAfter = 5 * time.Second
+	FleetLabel   = "fleet.kurator.dev/fleet-name"
+)
 
 // FleetManager reconciles a Cluster object
 type FleetManager struct {

--- a/pkg/fleet-manager/fleet_plugin.go
+++ b/pkg/fleet-manager/fleet_plugin.go
@@ -37,8 +37,6 @@ const (
 	PrometheusThanosServiceName = "prometheus-prometheus-thanos"
 
 	NoneClusterIP = "None"
-
-	FleetPluinLabel = "fleet.kurator.dev/plugin-typo"
 )
 
 func (f *FleetManager) reconcilePlugins(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*fleetCluster) (ctrl.Result, error) {

--- a/pkg/fleet-manager/fleet_plugin.go
+++ b/pkg/fleet-manager/fleet_plugin.go
@@ -38,7 +38,7 @@ const (
 
 	NoneClusterIP = "None"
 
-	FleetPluinLabel = "fleet.kurator.dev/fleet-plugin"
+	FleetPluinLabel = "fleet.kurator.dev/plugin-typo"
 )
 
 func (f *FleetManager) reconcilePlugins(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*fleetCluster) (ctrl.Result, error) {
@@ -84,7 +84,7 @@ func (f *FleetManager) reconcilePlugins(ctx context.Context, fleet *fleetapi.Fle
 			if res.err != nil {
 				errs = append(errs, res.err)
 			}
-			if res.ctrlResult.RequeueAfter > 0 {
+			if res.ctrlResult.Requeue || res.ctrlResult.RequeueAfter > 0 {
 				ctrlResults = append(ctrlResults, res.ctrlResult)
 			}
 			resources = append(resources, res.result...)

--- a/pkg/fleet-manager/fleet_plugin.go
+++ b/pkg/fleet-manager/fleet_plugin.go
@@ -18,6 +18,7 @@ package fleet
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	hrapiv2b1 "github.com/fluxcd/helm-controller/api/v2beta1"
@@ -36,6 +37,8 @@ const (
 	PrometheusThanosServiceName = "prometheus-prometheus-thanos"
 
 	NoneClusterIP = "None"
+
+	FleetPluinLabel = "fleet.kurator.dev/fleet-plugin"
 )
 
 func (f *FleetManager) reconcilePlugins(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*fleetCluster) (ctrl.Result, error) {
@@ -74,11 +77,27 @@ func (f *FleetManager) reconcilePlugins(ctx context.Context, fleet *fleetapi.Fle
 			close(resultsChannel)
 		}()
 
+		var errs []error
+		var ctrlResults []ctrl.Result
+
 		for res := range resultsChannel {
-			if res.err != nil || res.ctrlResult.RequeueAfter > 0 {
-				return res.ctrlResult, res.err
+			if res.err != nil {
+				errs = append(errs, res.err)
+			}
+			if res.ctrlResult.RequeueAfter > 0 {
+				ctrlResults = append(ctrlResults, res.ctrlResult)
 			}
 			resources = append(resources, res.result...)
+		}
+
+		if len(errs) > 0 {
+			// Combine all errors into one error message
+			return ctrl.Result{}, fmt.Errorf("encountered multiple errors: %v", errs)
+		}
+
+		if len(ctrlResults) > 0 {
+			// Handle multiple ctrlResults
+			return ctrlResults[0], nil // TODO: if we need strategy about RequeueAfter
 		}
 	}
 
@@ -108,11 +127,11 @@ func (f *FleetManager) reconcilePluginResources(ctx context.Context, fleet *flee
 	helmReleases := &hrapiv2b1.HelmReleaseList{}
 	fleetLabels := fleetResourceLables(fleet.Name)
 	if err := f.Client.List(ctx, helmRepos, client.InNamespace(fleet.Namespace), fleetLabels); err != nil {
-		log.Error(err, "failed to list helm repositories")
+		log.Error(err, "failed to list helm repository")
 		return ctrl.Result{}, err
 	}
 	if err := f.Client.List(ctx, helmReleases, client.InNamespace(fleet.Namespace), fleetLabels); err != nil {
-		log.Error(err, "failed to list helm repositories")
+		log.Error(err, "failed to list helm release")
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/fleet-manager/fleet_plugin.go
+++ b/pkg/fleet-manager/fleet_plugin.go
@@ -58,6 +58,12 @@ func (f *FleetManager) reconcilePlugins(ctx context.Context, fleet *fleetapi.Fle
 			return ctrlResult, err
 		}
 		resources = append(resources, result...)
+
+		result, ctrlResult, err = f.reconcileBackupPlugin(ctx, fleet, fleetClusters)
+		if err != nil || ctrlResult.RequeueAfter > 0 {
+			return ctrlResult, err
+		}
+		resources = append(resources, result...)
 	}
 
 	return f.reconcilePluginResources(ctx, fleet, resources)

--- a/pkg/fleet-manager/fleet_plugin_backup.go
+++ b/pkg/fleet-manager/fleet_plugin_backup.go
@@ -1,0 +1,105 @@
+/*
+Copyright Kurator Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fleet
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/kube"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"kurator.dev/kurator/pkg/apis/fleet/v1alpha1"
+	"kurator.dev/kurator/pkg/fleet-manager/plugin"
+	"kurator.dev/kurator/pkg/infra/util"
+)
+
+const (
+	AccessKey = "access-key"
+	SecretKey = "secret-key"
+)
+
+func (f *FleetManager) reconcileBackupPlugin(ctx context.Context, fleet *v1alpha1.Fleet, fleetClusters map[ClusterKey]*fleetCluster) (kube.ResourceList, ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	if fleet.Spec.Plugin.Backup == nil {
+		// reconcilePluginResources will delete all resources if plugin is nil
+		return nil, ctrl.Result{}, nil
+	}
+
+	veleroCfg := fleet.Spec.Plugin.Backup
+
+	fleetNN := types.NamespacedName{
+		Namespace: fleet.Namespace,
+		Name:      fleet.Name,
+	}
+
+	// fetch accessKey and secretKey from secret.
+	accessKey, secretKey, err := getObjStoreCredentials(ctx, f.Client, fleet.Namespace, fleet.Spec.Plugin.Backup.Storage.SecretName)
+	if err != nil {
+		return nil, ctrl.Result{}, err
+	}
+	fleetOwnerRef := ownerReference(fleet)
+	var resources kube.ResourceList
+	for key, cluster := range fleetClusters {
+		// generate Velero helm config for each fleet cluster
+		b, err := plugin.RenderVelero(f.Manifests, fleetNN, fleetOwnerRef, plugin.FleetCluster{
+			Name:       key.Name,
+			SecretName: cluster.Secret,
+			SecretKey:  cluster.SecretKey,
+		}, veleroCfg, accessKey, secretKey)
+		if err != nil {
+			return nil, ctrl.Result{}, err
+		}
+
+		// apply Velero helm resources
+		veleroResources, err := util.PatchResources(b)
+		if err != nil {
+			return nil, ctrl.Result{}, err
+		}
+		resources = append(resources, veleroResources...)
+	}
+
+	log.V(4).Info("wait for velero helm release to be reconciled")
+	if !f.helmReleaseReady(ctx, fleet, resources) {
+		// wait for HelmRelease to be ready
+		return nil, ctrl.Result{
+			// HelmRelease check interval is 1m, so we set 30s here
+			RequeueAfter: 30 * time.Second,
+		}, nil
+	}
+
+	return resources, ctrl.Result{}, nil
+}
+
+func getObjStoreCredentials(ctx context.Context, client client.Client, namespace, secretName string) (accessKey, secretKey string, err error) {
+	secret := &corev1.Secret{}
+	SecretNN := types.NamespacedName{
+		Namespace: namespace,
+		Name:      secretName,
+	}
+
+	if err := client.Get(ctx, SecretNN, secret); err != nil {
+		return "", "", errors.Wrapf(err, "failed to get cluster secret %s in namespace %s", secretName, namespace)
+	}
+
+	accessKey = string(secret.Data[AccessKey])
+	secretKey = string(secret.Data[SecretKey])
+
+	return accessKey, secretKey, nil
+}

--- a/pkg/fleet-manager/fleet_plugin_backup.go
+++ b/pkg/fleet-manager/fleet_plugin_backup.go
@@ -160,7 +160,7 @@ func (f *FleetManager) buildAWSSecret(ctx context.Context, secretName string, fl
 			Name:      s3SecretName,
 			Namespace: ObjStoreSecretNamespace,
 			Labels: map[string]string{
-				FleetPluinLabel: plugin.BackupPluginName,
+				FleetPluginName: plugin.BackupPluginName,
 			},
 		},
 		Type: corev1.SecretTypeOpaque,

--- a/pkg/fleet-manager/fleet_plugin_backup.go
+++ b/pkg/fleet-manager/fleet_plugin_backup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -44,6 +45,8 @@ const (
 	HuaWeiCloudObjStoreSecretName = "kurator-velero-obs"
 	GCPObjStoreSecretName         = "kurator-velero-gcs"
 	AzureObjStoreSecretName       = "kurator-velero-abs"
+
+	ObjStoreSecretNamespace = "velero"
 )
 
 // reconcileBackupPlugin reconciles the backup plugin configuration and installation across multiple clusters.
@@ -66,14 +69,16 @@ func (f *FleetManager) reconcileBackupPlugin(ctx context.Context, fleet *v1alpha
 	// handle provider-specific details
 	objStoreProvider := veleroCfg.Storage.Location.Provider
 	// newSecret is a variable used to store the newly created secret object which contains the necessary credentials for the object storage provider. The specific structure and content of the secret vary depending on the provider.
-	// providerValues is a map that stores default configurations associated with the specific provider. These configurations are necessary for the proper functioning of the Velero tool with the provider. Currently, this includes configurations for initContainers.
-	newSecret, err := f.getProviderDetails(ctx, veleroCfg.Storage.SecretName, objStoreProvider, fleetNN)
+	newSecret, err := f.buildNewSecret(ctx, veleroCfg.Storage.SecretName, objStoreProvider, fleetNN)
 	if err != nil {
+		log.Error(err, "failed to builder new object store secret")
 		return nil, ctrl.Result{}, err
 	}
 
 	fleetOwnerRef := ownerReference(fleet)
 	var resources kube.ResourceList
+
+	// Iterating through each fleet cluster to generate and apply Velero helm configurations.
 	for key, cluster := range fleetClusters {
 		// generate Velero helm config for each fleet cluster
 		b, err := plugin.RenderVelero(f.Manifests, fleetNN, fleetOwnerRef, plugin.FleetCluster{
@@ -82,6 +87,11 @@ func (f *FleetManager) reconcileBackupPlugin(ctx context.Context, fleet *v1alpha
 			SecretKey:  cluster.SecretKey,
 		}, veleroCfg, newSecret.Name)
 		if err != nil {
+			return nil, ctrl.Result{}, err
+		}
+
+		// create a new secret in the current fleet cluster before initializing the backup plugin.
+		if err := createNewSecretInFleetCluster(cluster, newSecret); err != nil {
 			return nil, ctrl.Result{}, err
 		}
 
@@ -102,11 +112,21 @@ func (f *FleetManager) reconcileBackupPlugin(ctx context.Context, fleet *v1alpha
 		}, nil
 	}
 
+	// After the HelmRelease reconciliation, we update the owner references of the new secrets to point to the Velero deployment.
+	// This ensures that when the Velero deployment (created by Kurator) is deleted, its associated secrets are cleaned up automatically,
+	// preventing orphaned resources and maintaining the cleanliness of the cluster.
+	for key, cluster := range fleetClusters {
+		if err := f.updateNewSecretOwnerReference(ctx, key.Name, cluster, newSecret); err != nil {
+			log.Error(err, "failed to update object store owner reference", "cluster", key.Name)
+			return nil, ctrl.Result{}, err
+		}
+	}
+
 	return resources, ctrl.Result{}, nil
 }
 
-// getProviderDetails retrieves the secret and provider values based on the specified object storage provider.
-func (f *FleetManager) getProviderDetails(ctx context.Context, secretName, objStoreProvider string, fleetNN types.NamespacedName) (*corev1.Secret, error) {
+// buildNewSecret generate a new secret for Velero based on the specified object storage provider.
+func (f *FleetManager) buildNewSecret(ctx context.Context, secretName, objStoreProvider string, fleetNN types.NamespacedName) (*corev1.Secret, error) {
 	var newSecret *corev1.Secret
 	var err error
 
@@ -138,7 +158,34 @@ func (f *FleetManager) buildAWSSecret(ctx context.Context, secretName string, fl
 	newSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      AWSObjStoreSecretName,
-			Namespace: fleetNN.Namespace,
+			Namespace: ObjStoreSecretNamespace,
+			Labels: map[string]string{
+				FleetPluinLabel: plugin.BackupPluginName,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"cloud": []byte(fmt.Sprintf("[default]\naws_access_key_id=%s\naws_secret_access_key=%s", accessKey, secretKey)),
+		},
+	}
+	return newSecret, nil
+}
+
+func (f *FleetManager) buildHuaWeiCloudSecret(ctx context.Context, secretName string, fleetNN types.NamespacedName) (*corev1.Secret, error) {
+	// fetch essential information from the user's secret
+	accessKey, secretKey, err := getObjStoreCredentials(ctx, f.Client, fleetNN.Namespace, secretName)
+	if err != nil {
+		return nil, err
+	}
+
+	// build an S3 secret for Velero using the accessKey and secretKey
+	newSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      HuaWeiCloudObjStoreSecretName,
+			Namespace: ObjStoreSecretNamespace,
+			Labels: map[string]string{
+				FleetPluinLabel: plugin.BackupPluginName,
+			},
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -149,9 +196,6 @@ func (f *FleetManager) buildAWSSecret(ctx context.Context, secretName string, fl
 }
 
 // TODO： accomplish those function after investigation
-func (f *FleetManager) buildHuaWeiCloudSecret(ctx context.Context, secretName string, fleetNN types.NamespacedName) (*corev1.Secret, error) {
-	return nil, nil
-}
 func (f *FleetManager) buildGCPSecret(ctx context.Context, secretName string, fleetNN types.NamespacedName) (*corev1.Secret, error) {
 	return nil, nil
 }
@@ -174,4 +218,56 @@ func getObjStoreCredentials(ctx context.Context, client client.Client, namespace
 	secretKey = string(secret.Data[SecretKey])
 
 	return accessKey, secretKey, nil
+}
+
+// createNewSecretInFleetCluster creates a new secret in the specified fleet cluster.
+// It takes a fleetCluster instance and a pre-built corev1.Secret instance as parameters.
+// It uses the kube client from the fleetCluster instance to create the new secret in the respective cluster.
+func createNewSecretInFleetCluster(cluster *fleetCluster, newSecret *corev1.Secret) error {
+	// Get the kubeclient.Interface instance
+	kubeClient := cluster.client.KubeClient()
+
+	// Get the namespace of the secret
+	namespace := newSecret.Namespace
+
+	// Create the new secret
+	if _, err := kubeClient.CoreV1().Secrets(namespace).Create(context.TODO(), newSecret, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+// updateNewSecretOwnerReference updates the OwnerReferences of the given secret in the specified fleet cluster.
+func (f *FleetManager) updateNewSecretOwnerReference(ctx context.Context, clusterName string, cluster *fleetCluster, newSecret *corev1.Secret) error {
+	// Get the kubeclient.Interface instance
+	kubeClient := cluster.client.KubeClient()
+
+	veleroDeploymentName := getVeleroDeploymentName(clusterName)
+	veleroDeployment, err := kubeClient.AppsV1().Deployments(newSecret.Namespace).Get(ctx, veleroDeploymentName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Set the OwnerReferences of the Secret to the Velero Deployment
+	newSecret.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       veleroDeployment.Name,
+			UID:        veleroDeployment.UID,
+		},
+	}
+
+	// Update the Secret object with the new OwnerReferences
+	if _, err := kubeClient.CoreV1().Secrets(newSecret.Namespace).Update(ctx, newSecret, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getVeleroDeploymentName returns the formatted deployment name in the current cluster.
+// The name is constructed as follows: "velero-" + "ComponentName" + "-" + clusterName.
+func getVeleroDeploymentName(clusterName string) string {
+	return fmt.Sprintf("velero-%s-%s", plugin.VeleroComponentName, clusterName)
 }

--- a/pkg/fleet-manager/fleet_plugin_grafana.go
+++ b/pkg/fleet-manager/fleet_plugin_grafana.go
@@ -31,7 +31,9 @@ import (
 	"kurator.dev/kurator/pkg/infra/util"
 )
 
-func (f *FleetManager) reconcileGrafanaPlugin(ctx context.Context, fleet *fleetapi.Fleet) (kube.ResourceList, ctrl.Result, error) {
+// reconcileGrafanaPlugin reconciles the Grafana plugin.
+// The fleetClusters parameter is currently unused, but is included to match the function signature of other functions in reconcilePlugins.
+func (f *FleetManager) reconcileGrafanaPlugin(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*fleetCluster) (kube.ResourceList, ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx).WithValues("fleet", client.ObjectKeyFromObject(fleet))
 
 	if fleet.Spec.Plugin.Grafana == nil {

--- a/pkg/fleet-manager/fleet_plugin_kyverno.go
+++ b/pkg/fleet-manager/fleet_plugin_kyverno.go
@@ -65,7 +65,7 @@ func (f *FleetManager) reconcileKyvernoPlugin(ctx context.Context, fleet *fleetv
 		resources = append(resources, kyvernoResources...)
 	}
 
-	log.V(4).Info("wait for grafana helm release to be reconciled")
+	log.V(4).Info("wait for kyverno helm release to be reconciled")
 	if !f.helmReleaseReady(ctx, fleet, resources) {
 		// wait for HelmRelease to be ready
 		return nil, ctrl.Result{

--- a/pkg/fleet-manager/fleet_plugin_metric.go
+++ b/pkg/fleet-manager/fleet_plugin_metric.go
@@ -287,7 +287,7 @@ func (f *FleetManager) reconcileMetricPlugin(ctx context.Context, fleet *fleetap
 			return nil, ctrl.Result{}, fmt.Errorf("failed to reconcile objstore secret for cluster %s: %w", c.Name, err)
 		}
 
-		b, err := plugin.RendPrometheus(f.Manifests, fleetNN, fleetOwnerRef, plugin.FleetCluster{
+		b, err := plugin.RenderPrometheus(f.Manifests, fleetNN, fleetOwnerRef, plugin.FleetCluster{
 			Name:       c.Name,
 			SecretName: fleetCluster.Secret,
 			SecretKey:  fleetCluster.SecretKey,

--- a/pkg/fleet-manager/manifests/plugin.tpl
+++ b/pkg/fleet-manager/manifests/plugin.tpl
@@ -47,7 +47,7 @@ spec:
         name: "{{ .ResourceName }}"
 {{- if or .Chart.Values  .Values }}
   values:
-    {{- merge .Values .Chart.Values | toYaml | nindent 4 }}
+    {{- merge .Values .Chart.Values | toYaml | trim | nindent 4 }}
 {{- end }}
   interval: 1m0s
   install:

--- a/pkg/fleet-manager/manifests/plugins/velero.yaml
+++ b/pkg/fleet-manager/manifests/plugins/velero.yaml
@@ -1,0 +1,18 @@
+type: default
+repo: https://vmware-tanzu.github.io/helm-charts
+name: velero
+version: 5.0.2
+targetNamespace: velero
+values:
+  image:
+    repository: velero/velero
+    tag: v1.11.1
+  deployNodeAgent: true
+  defaultVolumesToFsBackup: true
+  snapshotsEnabled: false
+  initContainers:
+    - image: velero/velero-plugin-for-aws:v1.7.1
+      name: velero-plugin-for-aws
+      volumeMounts:
+        - mountPath: /target
+          name: plugins

--- a/pkg/fleet-manager/manifests/plugins/velero.yaml
+++ b/pkg/fleet-manager/manifests/plugins/velero.yaml
@@ -10,9 +10,4 @@ values:
   deployNodeAgent: true
   defaultVolumesToFsBackup: true
   snapshotsEnabled: false
-  initContainers:
-    - image: velero/velero-plugin-for-aws:v1.7.1
-      name: velero-plugin-for-aws
-      volumeMounts:
-        - mountPath: /target
-          name: plugins
+

--- a/pkg/fleet-manager/plugin/plugin.go
+++ b/pkg/fleet-manager/plugin/plugin.go
@@ -18,6 +18,7 @@ package plugin
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"strings"
 
@@ -216,14 +217,9 @@ func RenderPrometheus(fsys fs.FS, fleetName types.NamespacedName, fleetRef *meta
 }
 
 type veleroObjectStoreLocation struct {
-	Bucket   string                          `json:"bucket"`
-	Provider string                          `json:"provider"`
-	Config   veleroObjectStoreLocationConfig `json:"config"`
-}
-type veleroObjectStoreLocationConfig struct {
-	S3Url            string `json:"s3Url"`
-	Region           string `json:"region"`
-	S3ForcePathStyle bool   `json:"s3ForcePathStyle"`
+	Bucket   string                 `json:"bucket"`
+	Provider string                 `json:"provider"`
+	Config   map[string]interface{} `json:"config"`
 }
 
 func RenderVelero(
@@ -243,25 +239,32 @@ func RenderVelero(
 
 	// get default values
 	defaultValues := c.Values
+	// providerValues is a map that stores default configurations associated with the specific provider. These configurations are necessary for the proper functioning of the Velero tool with the provider. Currently, this includes configurations for initContainers.
+	providerValues, err := getProviderValues(backupCfg.Storage.Location.Provider)
 	if err != nil {
 		return nil, err
 	}
 	// add providerValues to default values
-	providerValues := getProviderValues(backupCfg.Storage.Location.Provider)
 	defaultValues = transform.MergeMaps(defaultValues, providerValues)
 
 	// get custom values
-	customValues := map[string]interface{}{
+	customValues := map[string]interface{}{}
+	locationConfig := stringMapToInterfaceMap(backupCfg.Storage.Location.Config)
+	// generate velero config. "backupCfg.Storage.Location.Endpoint" and "backupCfg.Storage.Location.Region" will overwrite the value of "backupCfg.Storage.Location.config"
+	// because "backupCfg.Storage.Location.config" is optional, it should take effect only when current setting is not enough.
+	Config := transform.MergeMaps(locationConfig, map[string]interface{}{
+		"s3Url":            backupCfg.Storage.Location.Endpoint,
+		"region":           backupCfg.Storage.Location.Region,
+		"s3ForcePathStyle": true,
+	})
+	provider := getProviderFrombackupCfg(backupCfg)
+	configurationValues := map[string]interface{}{
 		"configuration": map[string]interface{}{
 			"backupStorageLocation": []veleroObjectStoreLocation{
 				{
 					Bucket:   backupCfg.Storage.Location.Bucket,
-					Provider: backupCfg.Storage.Location.Provider,
-					Config: veleroObjectStoreLocationConfig{
-						S3Url:            backupCfg.Storage.Location.Endpoint,
-						Region:           backupCfg.Storage.Location.Region,
-						S3ForcePathStyle: true,
-					},
+					Provider: provider,
+					Config:   Config,
 				},
 			},
 		},
@@ -270,6 +273,8 @@ func RenderVelero(
 			"existingSecret": veleroSecretName,
 		},
 	}
+	// add custom configurationValues to customValues
+	customValues = transform.MergeMaps(customValues, configurationValues)
 	extraValues, err := toMap(backupCfg.ExtraArgs)
 	if err != nil {
 		return nil, err
@@ -320,18 +325,29 @@ func toMap(args apiextensionsv1.JSON) (map[string]interface{}, error) {
 	return m, nil
 }
 
-func getProviderValues(provider string) map[string]interface{} {
+func stringMapToInterfaceMap(args map[string]string) map[string]interface{} {
+	m := make(map[string]interface{})
+	for s, s2 := range args {
+		m[s] = s2
+	}
+
+	return m
+}
+
+// getProviderValues return the map that stores default configurations associated with the specific provider.
+// The provider parameter can be one of the following values: "aws", "huaweicloud", "gcp", "azure".
+func getProviderValues(provider string) (map[string]interface{}, error) {
 	switch provider {
-	case "AWS":
-		return buildAWSProviderValues()
-	case "HuaWeiCloud":
-		return buildHuaWeiCloudProviderValues()
-	case "GCP":
-		return buildGCPProviderValues()
-	case "Azure":
-		return buildAzureProviderValues()
+	case "aws":
+		return buildAWSProviderValues(), nil
+	case "huaweicloud":
+		return buildHuaWeiCloudProviderValues(), nil
+	case "gcp":
+		return buildGCPProviderValues(), nil
+	case "azure":
+		return buildAzureProviderValues(), nil
 	default:
-		return nil
+		return nil, fmt.Errorf("unknown objStoreProvider: %v", provider)
 	}
 }
 
@@ -359,13 +375,23 @@ func buildAWSProviderValues() map[string]interface{} {
 	return values
 }
 
-// TODO： accomplish those function after investigation
 func buildHuaWeiCloudProviderValues() map[string]interface{} {
-	return nil
+	return buildAWSProviderValues()
 }
+
+// TODO： accomplish those function after investigation
 func buildGCPProviderValues() map[string]interface{} {
 	return nil
 }
 func buildAzureProviderValues() map[string]interface{} {
 	return nil
+}
+
+func getProviderFrombackupCfg(backupCfg *fleetv1a1.BackupConfig) string {
+	provider := backupCfg.Storage.Location.Provider
+	// there no "huaweicloud" provider in velero
+	if provider == "huaweicloud" {
+		provider = "aws"
+	}
+	return provider
 }

--- a/pkg/fleet-manager/plugin/plugin_test.go
+++ b/pkg/fleet-manager/plugin/plugin_test.go
@@ -351,7 +351,7 @@ func TestRenderVelero(t *testing.T) {
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",
-			}, tc.in, "xxx", "xxx")
+			}, tc.in, "xxx")
 			assert.NoError(t, err)
 
 			getExpected, err := getExpected("backup", tc.name)

--- a/pkg/fleet-manager/plugin/plugin_test.go
+++ b/pkg/fleet-manager/plugin/plugin_test.go
@@ -287,10 +287,11 @@ func TestRenderPrometheus(t *testing.T) {
 
 func TestRenderVelero(t *testing.T) {
 	cases := []struct {
-		name  string
-		fleet types.NamespacedName
-		ref   *metav1.OwnerReference
-		in    *v1alpha1.BackupConfig
+		name          string
+		fleet         types.NamespacedName
+		ref           *metav1.OwnerReference
+		in            *v1alpha1.BackupConfig
+		newSecretName string
 	}{
 		{
 			name: "default",
@@ -315,9 +316,10 @@ func TestRenderVelero(t *testing.T) {
 					SecretName: "backup-secret",
 				},
 			},
+			newSecretName: "kurator-velero-s3",
 		},
 		{
-			name: "custom-values",
+			name: "custom-values-s3",
 			fleet: types.NamespacedName{
 				Name:      "fleet-1",
 				Namespace: "default",
@@ -335,6 +337,10 @@ func TestRenderVelero(t *testing.T) {
 						Provider: "aws",
 						Endpoint: "http://x.x.x.x:x",
 						Region:   "minio",
+						Config: map[string]string{
+							"s3Url":  "s3.us-east-2.amazonaws.com",
+							"region": "us-east-2",
+						},
 					},
 					SecretName: "backup-secret",
 				},
@@ -342,6 +348,35 @@ func TestRenderVelero(t *testing.T) {
 					Raw: []byte("{\"image\": {\n  \"repository\": \"velero/velero\",\n  \"tag\": \"v1.10.1\",\n  \"pullPolicy\": \"IfNotPresent\"\n}}"),
 				},
 			},
+			newSecretName: "kurator-velero-s3",
+		},
+		{
+			name: "custom-values-obs",
+			fleet: types.NamespacedName{
+				Name:      "fleet-1",
+				Namespace: "default",
+			},
+			ref: &metav1.OwnerReference{
+				APIVersion: v1alpha1.GroupVersion.String(),
+				Kind:       "Fleet",
+				Name:       "fleet-1",
+				UID:        "xxxxxx",
+			},
+			in: &v1alpha1.BackupConfig{
+				Storage: v1alpha1.BackupStorage{
+					Location: v1alpha1.BackupStorageLocation{
+						Bucket:   "kurator-backup",
+						Provider: "huaweicloud",
+						Endpoint: "http://obs.cn-south-1.myhuaweicloud.com",
+						Region:   "cn-south-1",
+					},
+					SecretName: "backup-secret",
+				},
+				ExtraArgs: apiextensionsv1.JSON{
+					Raw: []byte("{\"image\": {\n  \"repository\": \"velero/velero\",\n  \"tag\": \"v1.10.1\",\n  \"pullPolicy\": \"IfNotPresent\"\n}}"),
+				},
+			},
+			newSecretName: "kurator-velero-obs",
 		},
 	}
 
@@ -351,7 +386,7 @@ func TestRenderVelero(t *testing.T) {
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",
-			}, tc.in, "xxx")
+			}, tc.in, tc.newSecretName)
 			assert.NoError(t, err)
 
 			getExpected, err := getExpected("backup", tc.name)

--- a/pkg/fleet-manager/plugin/testdata/backup/custom-values-obs.yaml
+++ b/pkg/fleet-manager/plugin/testdata/backup/custom-values-obs.yaml
@@ -44,20 +44,21 @@ spec:
   values:
     configuration:
       backupStorageLocation:
-      - bucket: velero
+      - bucket: kurator-backup
         config:
-          region: minio
+          region: cn-south-1
           s3ForcePathStyle: true
-          s3Url: http://x.x.x.x:x
+          s3Url: http://obs.cn-south-1.myhuaweicloud.com
         provider: aws
     credentials:
-      existingSecret: kurator-velero-s3
+      existingSecret: kurator-velero-obs
       useSecret: true
     defaultVolumesToFsBackup: true
     deployNodeAgent: true
     image:
+      pullPolicy: IfNotPresent
       repository: velero/velero
-      tag: v1.11.1
+      tag: v1.10.1
     initContainers:
     - image: velero/velero-plugin-for-aws:v1.7.1
       name: velero-plugin-for-aws

--- a/pkg/fleet-manager/plugin/testdata/backup/custom-values-s3.yaml
+++ b/pkg/fleet-manager/plugin/testdata/backup/custom-values-s3.yaml
@@ -51,9 +51,8 @@ spec:
           s3Url: http://x.x.x.x:x
         provider: aws
     credentials:
-      secretContents:
-        "useSecret": true,
-        "existingSecret": kurator-velero-s3,
+      existingSecret: kurator-velero-s3
+      useSecret: true
     defaultVolumesToFsBackup: true
     deployNodeAgent: true
     image:
@@ -67,7 +66,6 @@ spec:
       - mountPath: /target
         name: plugins
     snapshotsEnabled: false
-    
   interval: 1m0s
   install:
     createNamespace: true

--- a/pkg/fleet-manager/plugin/testdata/backup/custom-values.yaml
+++ b/pkg/fleet-manager/plugin/testdata/backup/custom-values.yaml
@@ -1,0 +1,82 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: "velero-cluster1"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/managed-by: fleet-manager
+    fleet.kurator.dev/name: "fleet-1"
+    fleet.kurator.dev/plugin: "backup"
+    fleet.kurator.dev/component: "velero"
+  ownerReferences:
+  - apiVersion: "fleet.kurator.dev/v1alpha1"
+    kind: "Fleet"
+    name: "fleet-1"
+    uid: "xxxxxx"
+spec:
+  type: "default"
+  interval: 5m0s
+  url: "https://vmware-tanzu.github.io/helm-charts"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: "velero-cluster1"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/managed-by: fleet-manager
+    fleet.kurator.dev/name: "fleet-1"
+    fleet.kurator.dev/plugin: "backup"
+    fleet.kurator.dev/component: "velero"
+  ownerReferences:
+  - apiVersion: "fleet.kurator.dev/v1alpha1"
+    kind: "Fleet"
+    name: "fleet-1"
+    uid: "xxxxxx"
+spec:
+  chart:
+    spec:
+      chart: "velero"
+      version: "5.0.2"
+      sourceRef:
+        kind: HelmRepository
+        name: "velero-cluster1"
+  values:
+    configuration:
+      backupStorageLocation:
+      - bucket: velero
+        config:
+          region: minio
+          s3ForcePathStyle: true
+          s3Url: http://x.x.x.x:x
+        provider: aws
+    credentials:
+      secretContents:
+        cloud: |-
+          [default]
+          aws_access_key_id=xxx
+          aws_secret_access_key=xxx
+    defaultVolumesToFsBackup: true
+    deployNodeAgent: true
+    image:
+      pullPolicy: IfNotPresent
+      repository: velero/velero
+      tag: v1.10.1
+    initContainers:
+    - image: velero/velero-plugin-for-aws:v1.7.1
+      name: velero-plugin-for-aws
+      volumeMounts:
+      - mountPath: /target
+        name: plugins
+    snapshotsEnabled: false
+    
+  interval: 1m0s
+  install:
+    createNamespace: true
+  targetNamespace: "velero"
+  storageNamespace: "velero"
+  timeout: 15m0s
+  kubeConfig:
+    secretRef:
+      name: cluster1
+      key: kubeconfig.yaml

--- a/pkg/fleet-manager/plugin/testdata/backup/custom-values.yaml
+++ b/pkg/fleet-manager/plugin/testdata/backup/custom-values.yaml
@@ -52,10 +52,8 @@ spec:
         provider: aws
     credentials:
       secretContents:
-        cloud: |-
-          [default]
-          aws_access_key_id=xxx
-          aws_secret_access_key=xxx
+        "useSecret": true,
+        "existingSecret": kurator-velero-s3,
     defaultVolumesToFsBackup: true
     deployNodeAgent: true
     image:

--- a/pkg/fleet-manager/plugin/testdata/backup/default.yaml
+++ b/pkg/fleet-manager/plugin/testdata/backup/default.yaml
@@ -1,0 +1,81 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: "velero-cluster1"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/managed-by: fleet-manager
+    fleet.kurator.dev/name: "fleet-1"
+    fleet.kurator.dev/plugin: "backup"
+    fleet.kurator.dev/component: "velero"
+  ownerReferences:
+  - apiVersion: "fleet.kurator.dev/v1alpha1"
+    kind: "Fleet"
+    name: "fleet-1"
+    uid: "xxxxxx"
+spec:
+  type: "default"
+  interval: 5m0s
+  url: "https://vmware-tanzu.github.io/helm-charts"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: "velero-cluster1"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/managed-by: fleet-manager
+    fleet.kurator.dev/name: "fleet-1"
+    fleet.kurator.dev/plugin: "backup"
+    fleet.kurator.dev/component: "velero"
+  ownerReferences:
+  - apiVersion: "fleet.kurator.dev/v1alpha1"
+    kind: "Fleet"
+    name: "fleet-1"
+    uid: "xxxxxx"
+spec:
+  chart:
+    spec:
+      chart: "velero"
+      version: "5.0.2"
+      sourceRef:
+        kind: HelmRepository
+        name: "velero-cluster1"
+  values:
+    configuration:
+      backupStorageLocation:
+      - bucket: velero
+        config:
+          region: minio
+          s3ForcePathStyle: true
+          s3Url: http://x.x.x.x:x
+        provider: aws
+    credentials:
+      secretContents:
+        cloud: |-
+          [default]
+          aws_access_key_id=xxx
+          aws_secret_access_key=xxx
+    defaultVolumesToFsBackup: true
+    deployNodeAgent: true
+    image:
+      repository: velero/velero
+      tag: v1.11.1
+    initContainers:
+    - image: velero/velero-plugin-for-aws:v1.7.1
+      name: velero-plugin-for-aws
+      volumeMounts:
+      - mountPath: /target
+        name: plugins
+    snapshotsEnabled: false
+    
+  interval: 1m0s
+  install:
+    createNamespace: true
+  targetNamespace: "velero"
+  storageNamespace: "velero"
+  timeout: 15m0s
+  kubeConfig:
+    secretRef:
+      name: cluster1
+      key: kubeconfig.yaml

--- a/pkg/fleet-manager/plugin/testdata/backup/default.yaml
+++ b/pkg/fleet-manager/plugin/testdata/backup/default.yaml
@@ -51,11 +51,8 @@ spec:
           s3Url: http://x.x.x.x:x
         provider: aws
     credentials:
-      secretContents:
-        cloud: |-
-          [default]
-          aws_access_key_id=xxx
-          aws_secret_access_key=xxx
+      "useSecret": true,
+      "existingSecret": kurator-velero-s3,
     defaultVolumesToFsBackup: true
     deployNodeAgent: true
     image:

--- a/pkg/fleet-manager/plugin/testdata/grafana/default.yaml
+++ b/pkg/fleet-manager/plugin/testdata/grafana/default.yaml
@@ -47,7 +47,6 @@ spec:
     fullnameOverride: grafana
     service:
       type: LoadBalancer
-    
   interval: 1m0s
   install:
     createNamespace: true

--- a/pkg/fleet-manager/plugin/testdata/grafana/with-datasource.yaml
+++ b/pkg/fleet-manager/plugin/testdata/grafana/with-datasource.yaml
@@ -56,7 +56,6 @@ spec:
     fullnameOverride: grafana
     service:
       type: LoadBalancer
-    
   interval: 1m0s
   install:
     createNamespace: true

--- a/pkg/fleet-manager/plugin/testdata/kyverno-policies/default.yaml
+++ b/pkg/fleet-manager/plugin/testdata/kyverno-policies/default.yaml
@@ -46,7 +46,6 @@ spec:
     podSecuritySeverity: medium
     podSecurityStandard: baseline
     validationFailureAction: Audit
-    
   interval: 1m0s
   install:
     createNamespace: true

--- a/pkg/fleet-manager/plugin/testdata/kyverno/default.yaml
+++ b/pkg/fleet-manager/plugin/testdata/kyverno/default.yaml
@@ -43,7 +43,6 @@ spec:
         name: "kyverno-cluster1"
   values:
     fullnameOverride: kyverno
-    
   interval: 1m0s
   install:
     createNamespace: true

--- a/pkg/fleet-manager/plugin/testdata/prometheus/default.yaml
+++ b/pkg/fleet-manager/plugin/testdata/prometheus/default.yaml
@@ -69,7 +69,6 @@ spec:
           secretName: thanos-objstore
         service:
           type: LoadBalancer
-    
   interval: 1m0s
   install:
     createNamespace: true

--- a/pkg/fleet-manager/plugin/testdata/prometheus/with-values.yaml
+++ b/pkg/fleet-manager/plugin/testdata/prometheus/with-values.yaml
@@ -60,7 +60,6 @@ spec:
           secretName: thanos-objstore
         service:
           type: LoadBalancer
-    
   interval: 1m0s
   install:
     createNamespace: true

--- a/pkg/fleet-manager/plugin/testdata/thanos/custom-values.yaml
+++ b/pkg/fleet-manager/plugin/testdata/thanos/custom-values.yaml
@@ -52,7 +52,6 @@ spec:
       enabled: false
     storegateway:
       enabled: true
-    
   interval: 1m0s
   install:
     createNamespace: true

--- a/pkg/fleet-manager/plugin/testdata/thanos/default.yaml
+++ b/pkg/fleet-manager/plugin/testdata/thanos/default.yaml
@@ -51,7 +51,6 @@ spec:
       enabled: false
     storegateway:
       enabled: true
-    
   interval: 1m0s
   install:
     createNamespace: true


### PR DESCRIPTION
**What type of PR is this?**


/kind cleanup
/kind feature


**What this PR does / why we need it**:


support for installing Velero in multi-cluster as a union by applying `Fleet`, which involves setting up the backup plugin.

part of #374 

the api implement of #378 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
support union install velero by apply fleet whoes backup plugin is set.

```

