### PR TITLE
cleanup: remove unused patch option

### DIFF
--- a/pkg/cluster-operator/attachedcluster_controller.go
+++ b/pkg/cluster-operator/attachedcluster_controller.go
@@ -74,8 +74,7 @@ func (a *AttachedClusterController) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	defer func() {
-		patchOpts := []patch.Option{}
-		if err := patchHelper.Patch(ctx, attachedCluster, patchOpts...); err != nil {
+		if err := patchHelper.Patch(ctx, attachedCluster); err != nil {
 			reterr = utilerrors.NewAggregate([]error{reterr, errors.Wrapf(err, "failed to patch fleet %s", req.NamespacedName)})
 		}
 	}()

--- a/pkg/fleet-manager/application_controller.go
+++ b/pkg/fleet-manager/application_controller.go
@@ -125,8 +125,7 @@ func (a *ApplicationManager) Reconcile(ctx context.Context, req ctrl.Request) (_
 	}
 
 	defer func() {
-		patchOpts := []patch.Option{}
-		if err := patchHelper.Patch(ctx, app, patchOpts...); err != nil {
+		if err := patchHelper.Patch(ctx, app); err != nil {
 			reterr = utilerrors.NewAggregate([]error{reterr, errors.Wrapf(err, "failed to patch application %s", req.NamespacedName)})
 		}
 	}()

--- a/pkg/fleet-manager/fleet.go
+++ b/pkg/fleet-manager/fleet.go
@@ -118,8 +118,7 @@ func (f *FleetManager) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.
 	}
 
 	defer func() {
-		patchOpts := []patch.Option{}
-		if err := patchHelper.Patch(ctx, fleet, patchOpts...); err != nil {
+		if err := patchHelper.Patch(ctx, fleet); err != nil {
 			reterr = utilerrors.NewAggregate([]error{reterr, errors.Wrapf(err, "failed to patch fleet %s", req.NamespacedName)})
 		}
 	}()


### PR DESCRIPTION
**What type of PR is this?**


/kind cleanup

**What this PR does / why we need it**:

The codebase contains several instances where a redundant empty slice declaration for patch options is used before calling `patchHelper.Patch`. 

This pr remove them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
cleanup: remove unused patch option
```

