### PR TITLE
Implement backup webhook server

### DIFF
--- a/pkg/webhooks/backup_webhook.go
+++ b/pkg/webhooks/backup_webhook.go
@@ -1,0 +1,100 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/robfig/cron/v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"kurator.dev/kurator/pkg/apis/backups/v1alpha1"
+)
+
+var _ webhook.CustomValidator = &BackupWebhook{}
+
+type BackupWebhook struct {
+	Client client.Reader
+}
+
+func (wh *BackupWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.Backup{}).
+		WithValidator(wh).
+		Complete()
+}
+
+func (wh *BackupWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	in, ok := obj.(*v1alpha1.Backup)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Backup but got a %T", obj))
+	}
+
+	return wh.validate(in)
+}
+
+func (wh *BackupWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	in, ok := newObj.(*v1alpha1.Backup)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Backup but got a %T", newObj))
+	}
+
+	return wh.validate(in)
+}
+
+func (wh *BackupWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+func (wh *BackupWebhook) validate(in *v1alpha1.Backup) error {
+	var allErrs field.ErrorList
+
+	// Validate Schedule
+	if len(in.Spec.Schedule) != 0 {
+		if _, err := cron.ParseStandard(in.Spec.Schedule); err != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("schedule"), in.Spec.Schedule, fmt.Sprintf("invalid cron expression: %s", err)))
+		}
+	}
+
+	// Validate referenced clusters in destination
+	if len(in.Spec.Destination.Clusters) != 0 {
+		// Validate referenced clusters in destination
+		allErrs = append(allErrs, validateDestinationClusters(in.Spec.Destination.Clusters)...)
+	}
+
+	// Validate Policy
+	if in.Spec.Policy != nil {
+		// Validate TTL
+		if in.Spec.Policy.TTL.Duration < 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("policy", "ttl"), in.Spec.Policy.TTL, "TTL cannot be negative"))
+		}
+		// Validate Resource Filter
+		allErrs = append(allErrs, validateResourceFilter(in.Spec.Policy.ResourceFilter)...)
+	}
+
+	if len(allErrs) > 0 {
+		return apierrors.NewInvalid(v1alpha1.SchemeGroupVersion.WithKind("Backup").GroupKind(), in.Name, allErrs)
+	}
+
+	return nil
+}

--- a/pkg/webhooks/backup_webhook_test.go
+++ b/pkg/webhooks/backup_webhook_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/yaml"
+
+	"kurator.dev/kurator/pkg/apis/backups/v1alpha1"
+)
+
+func TestInvalidBackupValidation(t *testing.T) {
+	r := path.Join("testdata", "backup")
+	caseNames := make([]string, 0)
+	err := filepath.WalkDir(r, func(path string, d fs.DirEntry, err error) error {
+		if d.IsDir() {
+			return nil
+		}
+		caseNames = append(caseNames, path)
+		return nil
+	})
+	assert.NoError(t, err)
+
+	wh := &BackupWebhook{}
+	for _, tt := range caseNames {
+		t.Run(tt, func(t *testing.T) {
+			g := NewWithT(t)
+			c, err := readBackup(tt)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			err = wh.validate(c)
+			g.Expect(err).To(HaveOccurred())
+			t.Logf("%v", err)
+		})
+	}
+}
+
+func readBackup(filename string) (*v1alpha1.Backup, error) {
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &v1alpha1.Backup{}
+	if err := yaml.Unmarshal(b, c); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/pkg/webhooks/testdata/backup/conflicting-namespace.yaml
+++ b/pkg/webhooks/testdata/backup/conflicting-namespace.yaml
@@ -1,0 +1,18 @@
+apiVersion: backups.kurator.dev/v1alpha1
+kind: Backup
+metadata:
+  name: conflicting-namespaces-example
+  namespace: default
+spec:
+  schedule: "0 0 * * *"
+  policy:
+    resourceFilter:
+      includedNamespaces:
+        - my-namespace
+      excludedNamespaces:
+        - my-namespace
+  destination:
+    fleet: quickstart
+    clusters:
+      - name: kurator-member1
+        kind: AttachedCluster

--- a/pkg/webhooks/testdata/backup/invalid-cron.yaml
+++ b/pkg/webhooks/testdata/backup/invalid-cron.yaml
@@ -1,0 +1,12 @@
+apiVersion: backups.kurator.dev/v1alpha1
+kind: Backup
+metadata:
+  name: invalid-cron-example
+  namespace: default
+spec:
+  schedule: "invalid-cron-format"
+  destination:
+    fleet: quickstart
+    clusters:
+      - name: kurator-member1
+        kind: AttachedCluster

--- a/pkg/webhooks/testdata/backup/missing-cluster-name.yaml
+++ b/pkg/webhooks/testdata/backup/missing-cluster-name.yaml
@@ -1,0 +1,10 @@
+apiVersion: backups.kurator.dev/v1alpha1
+kind: Backup
+metadata:
+  name: missing-cluster-name-example
+  namespace: default
+spec:
+  destination:
+    fleet: quickstart
+    clusters:
+      - kind: AttachedCluster

--- a/pkg/webhooks/testdata/backup/negative-ttl.yaml
+++ b/pkg/webhooks/testdata/backup/negative-ttl.yaml
@@ -1,0 +1,14 @@
+apiVersion: backups.kurator.dev/v1alpha1
+kind: Backup
+metadata:
+  name: negative-ttl-example
+  namespace: default
+spec:
+  schedule: "0 0 * * *"
+  policy:
+    ttl: -1h
+  destination:
+    fleet: quickstart
+    clusters:
+      - name: kurator-member1
+        kind: AttachedCluster


### PR DESCRIPTION
**What type of PR is this?**


/kind feature

**What this PR does / why we need it**:
part of #404 

added validation for the Backup custom resource using webhooks. 

added unit tests to validate the logic in the Fleet webhook. the result of UT:

```
=== RUN   TestInvalidBackupValidation
=== RUN   TestInvalidBackupValidation/testdata\backup\conflicting-namespace.yaml

    backup_webhook_test.go:54: Backup.backup.kurator.dev "conflicting-namespaces-example" is invalid: resourceFilter.includedNamespaces: Invalid value: "my-namespace": Namespace is already in excludedNamespaces
=== RUN   TestInvalidBackupValidation/testdata\backup\invalid-cron.yaml
    backup_webhook_test.go:54: Backup.backup.kurator.dev "invalid-cron-example" is invalid: schedule: Invalid value: "invalid-cron-format": invalid cron expression: expected exactly 5 fields, found 1: [invalid-cron-format]
=== RUN   TestInvalidBackupValidation/testdata\backup\missing-cluster-name.yaml
    backup_webhook_test.go:54: Backup.backup.kurator.dev "missing-cluster-name-example" is invalid: destination.clusters.name: Required value: Name of the referenced cluster is required
=== RUN   TestInvalidBackupValidation/testdata\backup\negative-ttl.yaml
    backup_webhook_test.go:54: Backup.backup.kurator.dev "negative-ttl-example" is invalid: policy.ttl: Invalid value: v1.Duration{Duration:-3600000000000}: TTL cannot be negative
--- PASS: TestInvalidBackupValidation (0.00s)
    --- PASS: TestInvalidBackupValidation/testdata\backup\conflicting-namespace.yaml (0.00s)
    --- PASS: TestInvalidBackupValidation/testdata\backup\invalid-cron.yaml (0.00s)
    --- PASS: TestInvalidBackupValidation/testdata\backup\missing-cluster-name.yaml (0.00s)
    --- PASS: TestInvalidBackupValidation/testdata\backup\negative-ttl.yaml (0.00s)
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
backup: init backup webhook
```

