### PR TITLE
backup: init restore webhook

### DIFF
--- a/pkg/webhooks/restore_webhook.go
+++ b/pkg/webhooks/restore_webhook.go
@@ -1,0 +1,65 @@
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"kurator.dev/kurator/pkg/apis/backups/v1alpha1"
+	"kurator.dev/kurator/pkg/webhooks/validation"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var _ webhook.CustomValidator = &RestoreWebhook{}
+
+type RestoreWebhook struct {
+	Client client.Reader
+}
+
+func (wh *RestoreWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.Restore{}).
+		WithValidator(wh).
+		Complete()
+}
+
+func (wh *RestoreWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	in, ok := obj.(*v1alpha1.Restore)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Restore but got a %T", obj))
+	}
+
+	return wh.validate(in)
+}
+
+func (wh *RestoreWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	in, ok := newObj.(*v1alpha1.Restore)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Restore but got a %T", newObj))
+	}
+
+	return wh.validate(in)
+}
+
+func (wh *RestoreWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+func (wh *RestoreWebhook) validate(in *v1alpha1.Restore) error {
+	var allErrs field.ErrorList
+
+	// Validate referenced clusters in destination
+	allErrs = append(allErrs, validation.ValidateDestinationClusters(in.Spec.Destination.Clusters)...)
+
+	// Validate Resource Filter
+	allErrs = append(allErrs, validation.ValidateResourceFilter(in.Spec.Policy.ResourceFilter)...)
+
+	if len(allErrs) > 0 {
+		return apierrors.NewInvalid(v1alpha1.SchemeGroupVersion.WithKind("Restore").GroupKind(), in.Name, allErrs)
+	}
+
+	return nil
+}

--- a/pkg/webhooks/restore_webhook_test.go
+++ b/pkg/webhooks/restore_webhook_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright Kurator Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/yaml"
+
+	"kurator.dev/kurator/pkg/apis/backups/v1alpha1"
+)
+
+func TestInvalidRestoreValidation(t *testing.T) {
+	r := path.Join("testdata", "restore")
+	caseNames := make([]string, 0)
+	err := filepath.WalkDir(r, func(path string, d fs.DirEntry, err error) error {
+		if d.IsDir() {
+			return nil
+		}
+		caseNames = append(caseNames, path)
+		return nil
+	})
+	assert.NoError(t, err)
+
+	wh := &RestoreWebhook{}
+	for _, tt := range caseNames {
+		t.Run(tt, func(t *testing.T) {
+			g := NewWithT(t)
+			c, err := readRestore(tt)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			err = wh.validate(c)
+			g.Expect(err).To(HaveOccurred())
+			t.Logf("%v", err)
+		})
+	}
+}
+
+func readRestore(filename string) (*v1alpha1.Restore, error) {
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &v1alpha1.Restore{}
+	if err := yaml.Unmarshal(b, c); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/pkg/webhooks/testdata/restore/invalid-destination-cluster.yaml
+++ b/pkg/webhooks/testdata/restore/invalid-destination-cluster.yaml
@@ -1,0 +1,9 @@
+apiVersion: backups.kurator.dev/v1alpha1
+kind: Restore
+metadata:
+  name: missing-cluster-name-restore
+spec:
+  backupName: test-backup
+  destination:
+    clusters:
+      - name: kurator-member1

--- a/pkg/webhooks/testdata/restore/invalid-resource-filter.yaml
+++ b/pkg/webhooks/testdata/restore/invalid-resource-filter.yaml
@@ -1,0 +1,12 @@
+apiVersion: backups.kurator.dev/v1alpha1
+kind: Restore
+metadata:
+  name: conflicting-namespaces-restore
+spec:
+  backupName: test-backup
+  policy:
+    resourceFilter:
+      includedNamespaces:
+        - "namespace1"
+      excludedNamespaces:
+        - "namespace1"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
part of #404

add webhook  validation for restore

since using the sam common func of backup webhook, this pr is rely on #410 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
backup: init restore webhook
```

