### PR TITLE
bugfix: make sure ns exsit when create velero secret

### DIFF
--- a/pkg/fleet-manager/fleet_plugin_backup.go
+++ b/pkg/fleet-manager/fleet_plugin_backup.go
@@ -21,11 +21,11 @@ import (
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"kurator.dev/kurator/pkg/apis/fleet/v1alpha1"
 	"kurator.dev/kurator/pkg/fleet-manager/plugin"
@@ -92,7 +92,7 @@ func (f *FleetManager) reconcileBackupPlugin(ctx context.Context, fleet *v1alpha
 		}
 
 		// create a new secret in the current fleet cluster before initializing the backup plugin.
-		if err := createNewSecretInFleetCluster(cluster, newSecret); err != nil {
+		if err := createNewSecretInFleetCluster(ctx, cluster, newSecret); err != nil {
 			err = fmt.Errorf("error creating new secret in fleet cluster %s: %w", key.Name, err)
 			return nil, ctrl.Result{}, err
 		}
@@ -205,35 +205,30 @@ func getObjStoreCredentials(ctx context.Context, client client.Client, namespace
 // createNewSecretInFleetCluster creates a new secret in the specified fleet cluster.
 // It takes a fleetCluster instance and a pre-built corev1.Secret instance as parameters.
 // It uses the kube client from the fleetCluster instance to create the new secret in the respective cluster.
-func createNewSecretInFleetCluster(cluster *fleetCluster, newSecret *corev1.Secret) error {
+func createNewSecretInFleetCluster(ctx context.Context, cluster *fleetCluster, newSecret *corev1.Secret) error {
 	// Get the kubeclient.Interface instance
-	kubeClient := cluster.client.KubeClient()
+	kubeClient := cluster.client.CtrlRuntimeClient()
 
 	// Get the namespace of the secret
 	namespace := newSecret.Namespace
-
-	// Check if namespace exists
-	_, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// Namespace does not exist, create it
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: namespace,
-				},
-			}
-			_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("failed to create namespace %s: %w", namespace, err)
-			}
-		} else {
-			return fmt.Errorf("failed to check for namespace %s: %w", namespace, err)
-		}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
 	}
 
-	// Create the new secret
-	if _, err := kubeClient.CoreV1().Secrets(namespace).Create(context.TODO(), newSecret, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("failed to create secret in namespace %s: %w", namespace, err)
+	// Create or update namespace
+	if _, syncErr := controllerutil.CreateOrUpdate(ctx, kubeClient, ns, func() error {
+		return nil
+	}); syncErr != nil {
+		return fmt.Errorf("failed to sync namespace %s: %w", namespace, syncErr)
+	}
+
+	// Create or update new secret
+	if _, syncErr := controllerutil.CreateOrUpdate(ctx, kubeClient, newSecret, func() error {
+		return nil
+	}); syncErr != nil {
+		return fmt.Errorf("failed to sync new secret in namespace %s: %w", namespace, syncErr)
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**


/kind bug


**What this PR does / why we need it**:

Ensures namespace exists in the target cluster before creating secrets, preventing potential failures.

Adds logic to check for namespace existence and creates it if missing, prior to secret creation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
bugfix: make sure ns exsit when create velero secret
```

