### PR TITLE
site: add feedback in each doc page

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -79,3 +79,19 @@ copyright = "The Kurator Authors"
 	url = "https://groups.google.com/g/kurator-dev"
 	icon = "fa fa-envelope"
   desc = "Kyverno mailing list"
+
+# Adds an H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
+# This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.
+# If you want this feature, but occasionally need to remove the "Feedback" section from a single page,
+# add "hide_feedback: true" to the page's front matter.
+[params.ui.feedback]
+enable = true
+# The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
+yes = 'Glad to hear it! Please <a href="https://github.com/kurator-dev/kurator/issues/new?assignees=&labels=kind%2Ffeature&projects=&template=enhancement.md">tell us how we can improve</a>.'
+no = 'Sorry to hear that. Please <a href="https://github.com/kurator-dev/kurator/issues/new">tell us how we can improve</a>.'
+
+[services]
+[services.googleAnalytics]
+# Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
+# "UA-00000000-0" is a placeholder Google Analytics ID, Future integration of actual analytics is straightforward, requiring only an update to the GA ID.
+id = "UA-00000000-0"


### PR DESCRIPTION
**What type of PR is this?**


/kind documentation

**What this PR does / why we need it**:
Implemented a feedback feature using a placeholder Google Analytics ID. This enables user feedback via GitHub issues, enhancing community engagement. Future integration of actual analytics is straightforward, requiring only an update to the GA ID.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
site: add feedback in each doc page
```
![image](https://github.com/kurator-dev/kurator/assets/45359033/7496645f-9ca1-4174-9ebc-3f90d3523470)
