### PR TITLE
rename FleetCluster to KubeConfigSecretRef 

### DIFF
--- a/pkg/fleet-manager/fleet_plugin_backup.go
+++ b/pkg/fleet-manager/fleet_plugin_backup.go
@@ -81,7 +81,7 @@ func (f *FleetManager) reconcileBackupPlugin(ctx context.Context, fleet *v1alpha
 	// Iterating through each fleet cluster to generate and apply Velero helm configurations.
 	for key, cluster := range fleetClusters {
 		// generate Velero helm config for each fleet cluster
-		b, err := plugin.RenderVelero(f.Manifests, fleetNN, fleetOwnerRef, plugin.FleetCluster{
+		b, err := plugin.RenderVelero(f.Manifests, fleetNN, fleetOwnerRef, plugin.RenderableFleetCluster{
 			Name:       key.Name,
 			SecretName: cluster.Secret,
 			SecretKey:  cluster.SecretKey,

--- a/pkg/fleet-manager/fleet_plugin_backup.go
+++ b/pkg/fleet-manager/fleet_plugin_backup.go
@@ -81,7 +81,7 @@ func (f *FleetManager) reconcileBackupPlugin(ctx context.Context, fleet *v1alpha
 	// Iterating through each fleet cluster to generate and apply Velero helm configurations.
 	for key, cluster := range fleetClusters {
 		// generate Velero helm config for each fleet cluster
-		b, err := plugin.RenderVelero(f.Manifests, fleetNN, fleetOwnerRef, plugin.RenderableFleetCluster{
+		b, err := plugin.RenderVelero(f.Manifests, fleetNN, fleetOwnerRef, plugin.KubeConfigSecretRef{
 			Name:       key.Name,
 			SecretName: cluster.Secret,
 			SecretKey:  cluster.SecretKey,

--- a/pkg/fleet-manager/fleet_plugin_distributedstorage.go
+++ b/pkg/fleet-manager/fleet_plugin_distributedstorage.go
@@ -46,7 +46,7 @@ func (f *FleetManager) reconcileDistributedStoragePlugin(ctx context.Context, fl
 
 	// First install rook-operator for the specified multicluster.
 	for key, cluster := range fleetClusters {
-		b, err := plugin.RendeStorageOperator(f.Manifests, fleetNN, fleetOwnerRef, plugin.RenderableFleetCluster{
+		b, err := plugin.RendeStorageOperator(f.Manifests, fleetNN, fleetOwnerRef, plugin.KubeConfigSecretRef{
 			Name:       key.Name,
 			SecretName: cluster.Secret,
 			SecretKey:  cluster.SecretKey,
@@ -75,7 +75,7 @@ func (f *FleetManager) reconcileDistributedStoragePlugin(ctx context.Context, fl
 	// After Rook operator are created, starts to install rook-ceph
 	if distributedStorageCfg.Storage != nil {
 		for key, cluster := range fleetClusters {
-			b, err := plugin.RenderClusterStorage(f.Manifests, fleetNN, fleetOwnerRef, plugin.RenderableFleetCluster{
+			b, err := plugin.RenderClusterStorage(f.Manifests, fleetNN, fleetOwnerRef, plugin.KubeConfigSecretRef{
 				Name:       key.Name,
 				SecretName: cluster.Secret,
 				SecretKey:  cluster.SecretKey,

--- a/pkg/fleet-manager/fleet_plugin_distributedstorage.go
+++ b/pkg/fleet-manager/fleet_plugin_distributedstorage.go
@@ -46,7 +46,7 @@ func (f *FleetManager) reconcileDistributedStoragePlugin(ctx context.Context, fl
 
 	// First install rook-operator for the specified multicluster.
 	for key, cluster := range fleetClusters {
-		b, err := plugin.RendeStorageOperator(f.Manifests, fleetNN, fleetOwnerRef, plugin.FleetCluster{
+		b, err := plugin.RendeStorageOperator(f.Manifests, fleetNN, fleetOwnerRef, plugin.RenderableFleetCluster{
 			Name:       key.Name,
 			SecretName: cluster.Secret,
 			SecretKey:  cluster.SecretKey,
@@ -75,7 +75,7 @@ func (f *FleetManager) reconcileDistributedStoragePlugin(ctx context.Context, fl
 	// After Rook operator are created, starts to install rook-ceph
 	if distributedStorageCfg.Storage != nil {
 		for key, cluster := range fleetClusters {
-			b, err := plugin.RenderClusterStorage(f.Manifests, fleetNN, fleetOwnerRef, plugin.FleetCluster{
+			b, err := plugin.RenderClusterStorage(f.Manifests, fleetNN, fleetOwnerRef, plugin.RenderableFleetCluster{
 				Name:       key.Name,
 				SecretName: cluster.Secret,
 				SecretKey:  cluster.SecretKey,

--- a/pkg/fleet-manager/fleet_plugin_kyverno.go
+++ b/pkg/fleet-manager/fleet_plugin_kyverno.go
@@ -48,7 +48,7 @@ func (f *FleetManager) reconcileKyvernoPlugin(ctx context.Context, fleet *fleetv
 	fleetOwnerRef := ownerReference(fleet)
 	var resources kube.ResourceList
 	for key, cluster := range fleetClusters {
-		b, err := plugin.RenderKyverno(f.Manifests, fleetNN, fleetOwnerRef, plugin.FleetCluster{
+		b, err := plugin.RenderKyverno(f.Manifests, fleetNN, fleetOwnerRef, plugin.RenderableFleetCluster{
 			Name:       key.Name,
 			SecretName: cluster.Secret,
 			SecretKey:  cluster.SecretKey,
@@ -78,7 +78,7 @@ func (f *FleetManager) reconcileKyvernoPlugin(ctx context.Context, fleet *fleetv
 	if kyvernoCfg.PodSecurity != nil {
 		for key, cluster := range fleetClusters {
 			// generate policies for pod security admission
-			b, err := plugin.RenderKyvernoPolicy(f.Manifests, fleetNN, fleetOwnerRef, plugin.FleetCluster{
+			b, err := plugin.RenderKyvernoPolicy(f.Manifests, fleetNN, fleetOwnerRef, plugin.RenderableFleetCluster{
 				Name:       key.Name,
 				SecretName: cluster.Secret,
 				SecretKey:  cluster.SecretKey,

--- a/pkg/fleet-manager/fleet_plugin_kyverno.go
+++ b/pkg/fleet-manager/fleet_plugin_kyverno.go
@@ -48,7 +48,7 @@ func (f *FleetManager) reconcileKyvernoPlugin(ctx context.Context, fleet *fleetv
 	fleetOwnerRef := ownerReference(fleet)
 	var resources kube.ResourceList
 	for key, cluster := range fleetClusters {
-		b, err := plugin.RenderKyverno(f.Manifests, fleetNN, fleetOwnerRef, plugin.RenderableFleetCluster{
+		b, err := plugin.RenderKyverno(f.Manifests, fleetNN, fleetOwnerRef, plugin.KubeConfigSecretRef{
 			Name:       key.Name,
 			SecretName: cluster.Secret,
 			SecretKey:  cluster.SecretKey,
@@ -78,7 +78,7 @@ func (f *FleetManager) reconcileKyvernoPlugin(ctx context.Context, fleet *fleetv
 	if kyvernoCfg.PodSecurity != nil {
 		for key, cluster := range fleetClusters {
 			// generate policies for pod security admission
-			b, err := plugin.RenderKyvernoPolicy(f.Manifests, fleetNN, fleetOwnerRef, plugin.RenderableFleetCluster{
+			b, err := plugin.RenderKyvernoPolicy(f.Manifests, fleetNN, fleetOwnerRef, plugin.KubeConfigSecretRef{
 				Name:       key.Name,
 				SecretName: cluster.Secret,
 				SecretKey:  cluster.SecretKey,

--- a/pkg/fleet-manager/fleet_plugin_metric.go
+++ b/pkg/fleet-manager/fleet_plugin_metric.go
@@ -286,7 +286,7 @@ func (f *FleetManager) reconcileMetricPlugin(ctx context.Context, fleet *fleetap
 			return nil, ctrl.Result{}, fmt.Errorf("failed to reconcile objstore secret for cluster %s: %w", c.Name, err)
 		}
 
-		b, err := plugin.RenderPrometheus(f.Manifests, fleetNN, fleetOwnerRef, plugin.RenderableFleetCluster{
+		b, err := plugin.RenderPrometheus(f.Manifests, fleetNN, fleetOwnerRef, plugin.KubeConfigSecretRef{
 			Name:       c.Name,
 			SecretName: fleetCluster.Secret,
 			SecretKey:  fleetCluster.SecretKey,

--- a/pkg/fleet-manager/fleet_plugin_metric.go
+++ b/pkg/fleet-manager/fleet_plugin_metric.go
@@ -286,7 +286,7 @@ func (f *FleetManager) reconcileMetricPlugin(ctx context.Context, fleet *fleetap
 			return nil, ctrl.Result{}, fmt.Errorf("failed to reconcile objstore secret for cluster %s: %w", c.Name, err)
 		}
 
-		b, err := plugin.RenderPrometheus(f.Manifests, fleetNN, fleetOwnerRef, plugin.FleetCluster{
+		b, err := plugin.RenderPrometheus(f.Manifests, fleetNN, fleetOwnerRef, plugin.RenderableFleetCluster{
 			Name:       c.Name,
 			SecretName: fleetCluster.Secret,
 			SecretKey:  fleetCluster.SecretKey,

--- a/pkg/fleet-manager/plugin/plugin.go
+++ b/pkg/fleet-manager/plugin/plugin.go
@@ -59,7 +59,7 @@ type GrafanaDataSource struct {
 	IsDefault  bool   `json:"isDefault"`
 }
 
-func RenderKyvernoPolicy(fsys fs.FS, fleetNN types.NamespacedName, fleetRef *metav1.OwnerReference, cluster FleetCluster, kyvernoCfg *fleetv1a1.KyvernoConfig) ([]byte, error) {
+func RenderKyvernoPolicy(fsys fs.FS, fleetNN types.NamespacedName, fleetRef *metav1.OwnerReference, cluster RenderableFleetCluster, kyvernoCfg *fleetv1a1.KyvernoConfig) ([]byte, error) {
 	c, err := getFleetPluginChart(fsys, KyvernoPolicyComponentName)
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func RenderKyvernoPolicy(fsys fs.FS, fleetNN types.NamespacedName, fleetRef *met
 	})
 }
 
-func RenderKyverno(fsys fs.FS, fleetNN types.NamespacedName, fleetRef *metav1.OwnerReference, cluster FleetCluster, kyvernoCfg *fleetv1a1.KyvernoConfig) ([]byte, error) {
+func RenderKyverno(fsys fs.FS, fleetNN types.NamespacedName, fleetRef *metav1.OwnerReference, cluster RenderableFleetCluster, kyvernoCfg *fleetv1a1.KyvernoConfig) ([]byte, error) {
 	c, err := getFleetPluginChart(fsys, KyvernoComponentName)
 	if err != nil {
 		return nil, err
@@ -181,7 +181,7 @@ func RenderThanos(fsys fs.FS, fleetNN types.NamespacedName, fleetRef *metav1.Own
 	return renderFleetPlugin(fsys, thanosCfg)
 }
 
-func RenderPrometheus(fsys fs.FS, fleetName types.NamespacedName, fleetRef *metav1.OwnerReference, cluster FleetCluster, metricCfg *fleetv1a1.MetricConfig) ([]byte, error) {
+func RenderPrometheus(fsys fs.FS, fleetName types.NamespacedName, fleetRef *metav1.OwnerReference, cluster RenderableFleetCluster, metricCfg *fleetv1a1.MetricConfig) ([]byte, error) {
 	promChart, err := getFleetPluginChart(fsys, PrometheusComponentName)
 	if err != nil {
 		return nil, err
@@ -230,7 +230,7 @@ func RenderVelero(
 	fsys fs.FS,
 	fleetNN types.NamespacedName,
 	fleetRef *metav1.OwnerReference,
-	cluster FleetCluster,
+	cluster RenderableFleetCluster,
 	backupCfg *fleetv1a1.BackupConfig,
 	veleroSecretName string,
 ) ([]byte, error) {
@@ -305,7 +305,7 @@ func RendeStorageOperator(
 	fsys fs.FS,
 	fleetNN types.NamespacedName,
 	fleetRef *metav1.OwnerReference,
-	cluster FleetCluster,
+	cluster RenderableFleetCluster,
 	distributedStorageCfg *fleetv1a1.DistributedStorageConfig,
 ) ([]byte, error) {
 	// get and merge the chart config
@@ -336,7 +336,7 @@ func RenderClusterStorage(
 	fsys fs.FS,
 	fleetNN types.NamespacedName,
 	fleetRef *metav1.OwnerReference,
-	cluster FleetCluster,
+	cluster RenderableFleetCluster,
 	distributedStorageCfg *fleetv1a1.DistributedStorageConfig,
 ) ([]byte, error) {
 	c, err := getFleetPluginChart(fsys, RookClusterComponentName)

--- a/pkg/fleet-manager/plugin/plugin.go
+++ b/pkg/fleet-manager/plugin/plugin.go
@@ -59,7 +59,7 @@ type GrafanaDataSource struct {
 	IsDefault  bool   `json:"isDefault"`
 }
 
-func RenderKyvernoPolicy(fsys fs.FS, fleetNN types.NamespacedName, fleetRef *metav1.OwnerReference, cluster RenderableFleetCluster, kyvernoCfg *fleetv1a1.KyvernoConfig) ([]byte, error) {
+func RenderKyvernoPolicy(fsys fs.FS, fleetNN types.NamespacedName, fleetRef *metav1.OwnerReference, cluster KubeConfigSecretRef, kyvernoCfg *fleetv1a1.KyvernoConfig) ([]byte, error) {
 	c, err := getFleetPluginChart(fsys, KyvernoPolicyComponentName)
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func RenderKyvernoPolicy(fsys fs.FS, fleetNN types.NamespacedName, fleetRef *met
 	})
 }
 
-func RenderKyverno(fsys fs.FS, fleetNN types.NamespacedName, fleetRef *metav1.OwnerReference, cluster RenderableFleetCluster, kyvernoCfg *fleetv1a1.KyvernoConfig) ([]byte, error) {
+func RenderKyverno(fsys fs.FS, fleetNN types.NamespacedName, fleetRef *metav1.OwnerReference, cluster KubeConfigSecretRef, kyvernoCfg *fleetv1a1.KyvernoConfig) ([]byte, error) {
 	c, err := getFleetPluginChart(fsys, KyvernoComponentName)
 	if err != nil {
 		return nil, err
@@ -181,7 +181,7 @@ func RenderThanos(fsys fs.FS, fleetNN types.NamespacedName, fleetRef *metav1.Own
 	return renderFleetPlugin(fsys, thanosCfg)
 }
 
-func RenderPrometheus(fsys fs.FS, fleetName types.NamespacedName, fleetRef *metav1.OwnerReference, cluster RenderableFleetCluster, metricCfg *fleetv1a1.MetricConfig) ([]byte, error) {
+func RenderPrometheus(fsys fs.FS, fleetName types.NamespacedName, fleetRef *metav1.OwnerReference, cluster KubeConfigSecretRef, metricCfg *fleetv1a1.MetricConfig) ([]byte, error) {
 	promChart, err := getFleetPluginChart(fsys, PrometheusComponentName)
 	if err != nil {
 		return nil, err
@@ -230,7 +230,7 @@ func RenderVelero(
 	fsys fs.FS,
 	fleetNN types.NamespacedName,
 	fleetRef *metav1.OwnerReference,
-	cluster RenderableFleetCluster,
+	cluster KubeConfigSecretRef,
 	backupCfg *fleetv1a1.BackupConfig,
 	veleroSecretName string,
 ) ([]byte, error) {
@@ -305,7 +305,7 @@ func RendeStorageOperator(
 	fsys fs.FS,
 	fleetNN types.NamespacedName,
 	fleetRef *metav1.OwnerReference,
-	cluster RenderableFleetCluster,
+	cluster KubeConfigSecretRef,
 	distributedStorageCfg *fleetv1a1.DistributedStorageConfig,
 ) ([]byte, error) {
 	// get and merge the chart config
@@ -336,7 +336,7 @@ func RenderClusterStorage(
 	fsys fs.FS,
 	fleetNN types.NamespacedName,
 	fleetRef *metav1.OwnerReference,
-	cluster RenderableFleetCluster,
+	cluster KubeConfigSecretRef,
 	distributedStorageCfg *fleetv1a1.DistributedStorageConfig,
 ) ([]byte, error) {
 	c, err := getFleetPluginChart(fsys, RookClusterComponentName)

--- a/pkg/fleet-manager/plugin/plugin_test.go
+++ b/pkg/fleet-manager/plugin/plugin_test.go
@@ -58,7 +58,7 @@ func TestRenderKyvernoPolicy(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := RenderKyvernoPolicy(manifestFS, tc.fleet, tc.ref, FleetCluster{
+			got, err := RenderKyvernoPolicy(manifestFS, tc.fleet, tc.ref, RenderableFleetCluster{
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",
@@ -98,7 +98,7 @@ func TestRenderKyverno(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := RenderKyverno(manifestFS, tc.fleet, tc.ref, FleetCluster{
+			got, err := RenderKyverno(manifestFS, tc.fleet, tc.ref, RenderableFleetCluster{
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",
@@ -270,7 +270,7 @@ func TestRenderPrometheus(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := RenderPrometheus(manifestFS, tc.fleet, tc.ref, FleetCluster{
+			got, err := RenderPrometheus(manifestFS, tc.fleet, tc.ref, RenderableFleetCluster{
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",
@@ -382,7 +382,7 @@ func TestRenderVelero(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := RenderVelero(manifestFS, tc.fleet, tc.ref, FleetCluster{
+			got, err := RenderVelero(manifestFS, tc.fleet, tc.ref, RenderableFleetCluster{
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",
@@ -437,7 +437,7 @@ func TestRenderStorageOperator(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := RendeStorageOperator(manifestFS, tc.fleet, tc.ref, FleetCluster{
+			got, err := RendeStorageOperator(manifestFS, tc.fleet, tc.ref, RenderableFleetCluster{
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",
@@ -527,7 +527,7 @@ func TestRenderClusterStorage(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := RenderClusterStorage(manifestFS, tc.fleet, tc.ref, FleetCluster{
+			got, err := RenderClusterStorage(manifestFS, tc.fleet, tc.ref, RenderableFleetCluster{
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",

--- a/pkg/fleet-manager/plugin/plugin_test.go
+++ b/pkg/fleet-manager/plugin/plugin_test.go
@@ -58,7 +58,7 @@ func TestRenderKyvernoPolicy(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := RenderKyvernoPolicy(manifestFS, tc.fleet, tc.ref, RenderableFleetCluster{
+			got, err := RenderKyvernoPolicy(manifestFS, tc.fleet, tc.ref, KubeConfigSecretRef{
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",
@@ -98,7 +98,7 @@ func TestRenderKyverno(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := RenderKyverno(manifestFS, tc.fleet, tc.ref, RenderableFleetCluster{
+			got, err := RenderKyverno(manifestFS, tc.fleet, tc.ref, KubeConfigSecretRef{
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",
@@ -270,7 +270,7 @@ func TestRenderPrometheus(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := RenderPrometheus(manifestFS, tc.fleet, tc.ref, RenderableFleetCluster{
+			got, err := RenderPrometheus(manifestFS, tc.fleet, tc.ref, KubeConfigSecretRef{
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",
@@ -382,7 +382,7 @@ func TestRenderVelero(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := RenderVelero(manifestFS, tc.fleet, tc.ref, RenderableFleetCluster{
+			got, err := RenderVelero(manifestFS, tc.fleet, tc.ref, KubeConfigSecretRef{
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",
@@ -437,7 +437,7 @@ func TestRenderStorageOperator(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := RendeStorageOperator(manifestFS, tc.fleet, tc.ref, RenderableFleetCluster{
+			got, err := RendeStorageOperator(manifestFS, tc.fleet, tc.ref, KubeConfigSecretRef{
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",
@@ -527,7 +527,7 @@ func TestRenderClusterStorage(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := RenderClusterStorage(manifestFS, tc.fleet, tc.ref, RenderableFleetCluster{
+			got, err := RenderClusterStorage(manifestFS, tc.fleet, tc.ref, KubeConfigSecretRef{
 				Name:       "cluster1",
 				SecretName: "cluster1",
 				SecretKey:  "kubeconfig.yaml",

--- a/pkg/fleet-manager/plugin/render.go
+++ b/pkg/fleet-manager/plugin/render.go
@@ -32,7 +32,7 @@ type FleetPluginConfig struct {
 	Component      string
 	Fleet          types.NamespacedName
 	OwnerReference *metav1.OwnerReference
-	Cluster        *RenderableFleetCluster
+	Cluster        *KubeConfigSecretRef
 	Chart          ChartConfig
 	Values         map[string]interface{}
 }
@@ -55,7 +55,7 @@ func (plugin FleetPluginConfig) StorageNamespace() string {
 	return plugin.Fleet.Namespace
 }
 
-type RenderableFleetCluster struct {
+type KubeConfigSecretRef struct {
 	Name       string
 	SecretName string
 	SecretKey  string

--- a/pkg/fleet-manager/plugin/render.go
+++ b/pkg/fleet-manager/plugin/render.go
@@ -32,7 +32,7 @@ type FleetPluginConfig struct {
 	Component      string
 	Fleet          types.NamespacedName
 	OwnerReference *metav1.OwnerReference
-	Cluster        *FleetCluster
+	Cluster        *RenderableFleetCluster
 	Chart          ChartConfig
 	Values         map[string]interface{}
 }
@@ -55,7 +55,7 @@ func (plugin FleetPluginConfig) StorageNamespace() string {
 	return plugin.Fleet.Namespace
 }
 
-type FleetCluster struct {
+type RenderableFleetCluster struct {
 	Name       string
 	SecretName string
 	SecretKey  string


### PR DESCRIPTION
**What type of PR is this?**


/kind cleanup


**What this PR does / why we need it**:

current `FleetCluster`  struct is just for render

and we have already defined `fleetCluster `  here

https://github.com/kurator-dev/kurator/blob/2871c99124b0f27a3fcdd9542fb41db0b5cf1d89/pkg/fleet-manager/fleet_cluster.go#L34-L38

and we are going to make it public for #481 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

