### PR TITLE
rename fleetCluster to FleetCluster to make it public

### DIFF
--- a/pkg/fleet-manager/backup_controller.go
+++ b/pkg/fleet-manager/backup_controller.go
@@ -107,7 +107,7 @@ func (b *BackupManager) reconcileBackup(ctx context.Context, backup *backupapi.B
 }
 
 // reconcileBackupResources converts the backup resources into velero backup resources that can be used by Velero on the target clusters, and applies each of these backup resources to the respective target clusters.
-func (b *BackupManager) reconcileBackupResources(ctx context.Context, backup *backupapi.Backup, destinationClusters map[ClusterKey]*fleetCluster) (ctrl.Result, error) {
+func (b *BackupManager) reconcileBackupResources(ctx context.Context, backup *backupapi.Backup, destinationClusters map[ClusterKey]*FleetCluster) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	backupLabel := generateVeleroInstanceLabel(BackupNameLabel, backup.Name, backup.Spec.Destination.Fleet)
@@ -148,7 +148,7 @@ func (b *BackupManager) reconcileBackupResources(ctx context.Context, backup *ba
 }
 
 // reconcileBackupStatus updates the synchronization status of each backup resource.
-func (b *BackupManager) reconcileBackupStatus(ctx context.Context, backup *backupapi.Backup, destinationClusters map[ClusterKey]*fleetCluster) (ctrl.Result, error) {
+func (b *BackupManager) reconcileBackupStatus(ctx context.Context, backup *backupapi.Backup, destinationClusters map[ClusterKey]*FleetCluster) (ctrl.Result, error) {
 	// Initialize a map to store the status of each cluster currently recorded. The combination of detail.ClusterName, detail.ClusterKind, and detail.BackupNameInCluster uniquely identifies a Velero backup object.
 	statusMap := make(map[string]*backupapi.BackupDetails)
 	for _, detail := range backup.Status.Details {
@@ -164,7 +164,7 @@ func (b *BackupManager) reconcileBackupStatus(ctx context.Context, backup *backu
 
 // reconcileOneTimeBackupStatus updates the status of a one-time Backup object by checking the status of corresponding Velero backup resources in each target cluster.
 // It determines whether to requeue the reconciliation based on the completion status of all Velero backup resources.
-func (b *BackupManager) reconcileOneTimeBackupStatus(ctx context.Context, backup *backupapi.Backup, destinationClusters map[ClusterKey]*fleetCluster, statusMap map[string]*backupapi.BackupDetails) (ctrl.Result, error) {
+func (b *BackupManager) reconcileOneTimeBackupStatus(ctx context.Context, backup *backupapi.Backup, destinationClusters map[ClusterKey]*FleetCluster, statusMap map[string]*backupapi.BackupDetails) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Loop through each target cluster to retrieve the status of Velero backup resources using the client associated with the respective target cluster.
@@ -207,7 +207,7 @@ func (b *BackupManager) reconcileOneTimeBackupStatus(ctx context.Context, backup
 
 // reconcileScheduleBackupStatus manages the status synchronization for scheduled Backup objects.
 // If the backup type is "schedule", new backups will be continuously generated, hence the status synchronization will be executed continuously.
-func (b *BackupManager) reconcileScheduleBackupStatus(ctx context.Context, schedule *backupapi.Backup, destinationClusters map[ClusterKey]*fleetCluster, statusMap map[string]*backupapi.BackupDetails) (ctrl.Result, error) {
+func (b *BackupManager) reconcileScheduleBackupStatus(ctx context.Context, schedule *backupapi.Backup, destinationClusters map[ClusterKey]*FleetCluster, statusMap map[string]*backupapi.BackupDetails) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Loop through each target cluster to retrieve the status of Velero backup created by schedule resources using the client associated with the respective target cluster.

--- a/pkg/fleet-manager/backup_restore_migrate_shared.go
+++ b/pkg/fleet-manager/backup_restore_migrate_shared.go
@@ -60,7 +60,7 @@ const (
 )
 
 // fetchDestinationClusters retrieves the clusters from the specified destination and filters them based on the 'Clusters' defined in the destination. It returns a map of selected clusters along with any error encountered during the process.
-func fetchDestinationClusters(ctx context.Context, kubeClient client.Client, namespace string, destination backupapi.Destination) (map[ClusterKey]*fleetCluster, error) {
+func fetchDestinationClusters(ctx context.Context, kubeClient client.Client, namespace string, destination backupapi.Destination) (map[ClusterKey]*FleetCluster, error) {
 	// Fetch fleet instance
 	fleet := &fleetapi.Fleet{}
 	fleetKey := client.ObjectKey{
@@ -81,7 +81,7 @@ func fetchDestinationClusters(ctx context.Context, kubeClient client.Client, nam
 		return fleetClusters, nil
 	}
 
-	selectedFleetCluster := make(map[ClusterKey]*fleetCluster)
+	selectedFleetCluster := make(map[ClusterKey]*FleetCluster)
 	// Check and return clusters with client
 	for _, cluster := range destination.Clusters {
 		name := cluster.Name
@@ -142,13 +142,13 @@ func buildVeleroBackupSpec(backupPolicy *backupapi.BackupPolicy) velerov1.Backup
 	}
 }
 
-func newSyncVeleroTaskFunc(ctx context.Context, clusterAccess *fleetCluster, obj client.Object) func() error {
+func newSyncVeleroTaskFunc(ctx context.Context, clusterAccess *FleetCluster, obj client.Object) func() error {
 	return func() error {
 		return syncVeleroObj(ctx, clusterAccess, obj)
 	}
 }
 
-func syncVeleroObj(ctx context.Context, cluster *fleetCluster, veleroObj client.Object) error {
+func syncVeleroObj(ctx context.Context, cluster *FleetCluster, veleroObj client.Object) error {
 	// Get the client
 	clusterClient := cluster.client.CtrlRuntimeClient()
 
@@ -183,7 +183,7 @@ func allBackupsCompleted(status backupapi.BackupStatus) bool {
 // Returns:
 // - error: if any error occurs during the deletion process
 // deleteResourcesInClusters deletes instances of a Kubernetes resource based on the specified label key and value.
-func deleteResourcesInClusters(ctx context.Context, namespace, labelKey string, labelValue string, destinationClusters map[ClusterKey]*fleetCluster, objList client.ObjectList) error {
+func deleteResourcesInClusters(ctx context.Context, namespace, labelKey string, labelValue string, destinationClusters map[ClusterKey]*FleetCluster, objList client.ObjectList) error {
 	// Log setup
 	log := ctrl.LoggerFrom(ctx)
 
@@ -288,7 +288,7 @@ func GetCronInterval(cronExpr string) (time.Duration, error) {
 }
 
 // getResourceFromClusterClient retrieves a specific Kubernetes resource from the provided cluster.
-func getResourceFromClusterClient(ctx context.Context, name, namespace string, clusterAccess fleetCluster, obj client.Object) error {
+func getResourceFromClusterClient(ctx context.Context, name, namespace string, clusterAccess FleetCluster, obj client.Object) error {
 	clusterClient := clusterAccess.client.CtrlRuntimeClient()
 
 	resourceKey := types.NamespacedName{
@@ -299,7 +299,7 @@ func getResourceFromClusterClient(ctx context.Context, name, namespace string, c
 }
 
 // listResourcesFromClusterClient retrieves resources from a cluster based on the provided namespace and label.
-func listResourcesFromClusterClient(ctx context.Context, namespace string, labelKey string, labelValue string, clusterAccess fleetCluster, objList client.ObjectList) error {
+func listResourcesFromClusterClient(ctx context.Context, namespace string, labelKey string, labelValue string, clusterAccess FleetCluster, objList client.ObjectList) error {
 	// Create the cluster client
 	clusterClient := clusterAccess.client.CtrlRuntimeClient()
 	// Create the label selector
@@ -320,9 +320,9 @@ func listResourcesFromClusterClient(ctx context.Context, namespace string, label
 //
 // Returns:
 // - string: The name of the fleet where the restore's set of fleetClusters resides.
-// - map[ClusterKey]*fleetCluster: A map of cluster keys to fleet clusters.
+// - map[ClusterKey]*FleetCluster: A map of cluster keys to fleet clusters.
 // - error: An error object indicating any issues encountered during the operation.
-func (r *RestoreManager) fetchRestoreDestinationClusters(ctx context.Context, restore *backupapi.Restore) (string, map[ClusterKey]*fleetCluster, error) {
+func (r *RestoreManager) fetchRestoreDestinationClusters(ctx context.Context, restore *backupapi.Restore) (string, map[ClusterKey]*FleetCluster, error) {
 	// Retrieve the referred backup in the current Kurator host cluster
 	key := client.ObjectKey{
 		Name:      restore.Spec.BackupName,
@@ -365,7 +365,7 @@ func (r *RestoreManager) fetchRestoreDestinationClusters(ctx context.Context, re
 }
 
 // isFleetClusterSubset is the helper function to check if one set of clusters is a subset of another
-func isFleetClusterSubset(baseClusters, subsetClusters map[ClusterKey]*fleetCluster) bool {
+func isFleetClusterSubset(baseClusters, subsetClusters map[ClusterKey]*FleetCluster) bool {
 	for key := range subsetClusters {
 		if _, exists := baseClusters[key]; !exists {
 			return false
@@ -418,7 +418,7 @@ func allRestoreCompleted(clusterDetails []*backupapi.RestoreDetails) bool {
 
 // syncVeleroRestoreStatus synchronizes the status of Velero restore resources across different clusters.
 // Note: Returns the modified ClusterDetails to capture internal changes due to Go's slice behavior.
-func syncVeleroRestoreStatus(ctx context.Context, destinationClusters map[ClusterKey]*fleetCluster, clusterDetails []*backupapi.RestoreDetails, creatorKind, creatorNamespace, creatorName string) ([]*backupapi.RestoreDetails, error) {
+func syncVeleroRestoreStatus(ctx context.Context, destinationClusters map[ClusterKey]*FleetCluster, clusterDetails []*backupapi.RestoreDetails, creatorKind, creatorNamespace, creatorName string) ([]*backupapi.RestoreDetails, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if clusterDetails == nil {

--- a/pkg/fleet-manager/backup_restore_migrate_shared_test.go
+++ b/pkg/fleet-manager/backup_restore_migrate_shared_test.go
@@ -543,41 +543,41 @@ func getExpectedRestore(caseName string) ([]byte, error) {
 func TestIsFleetClusterSubset(t *testing.T) {
 	tests := []struct {
 		name           string
-		baseClusters   map[ClusterKey]*fleetCluster
-		subsetClusters map[ClusterKey]*fleetCluster
+		baseClusters   map[ClusterKey]*FleetCluster
+		subsetClusters map[ClusterKey]*FleetCluster
 		wantResult     bool
 	}{
 		{
 			name: "Subset is a true subset of base",
-			baseClusters: map[ClusterKey]*fleetCluster{
+			baseClusters: map[ClusterKey]*FleetCluster{
 				{"Kind1", "Name1"}: {},
 				{"Kind2", "Name2"}: {},
 			},
-			subsetClusters: map[ClusterKey]*fleetCluster{
+			subsetClusters: map[ClusterKey]*FleetCluster{
 				{"Kind1", "Name1"}: {},
 			},
 			wantResult: true,
 		},
 		{
 			name: "Subset is not a subset of base",
-			baseClusters: map[ClusterKey]*fleetCluster{
+			baseClusters: map[ClusterKey]*FleetCluster{
 				{"Kind1", "Name1"}: {},
 			},
-			subsetClusters: map[ClusterKey]*fleetCluster{
+			subsetClusters: map[ClusterKey]*FleetCluster{
 				{"Kind2", "Name2"}: {},
 			},
 			wantResult: false,
 		},
 		{
 			name:           "Both base and subset are empty",
-			baseClusters:   map[ClusterKey]*fleetCluster{},
-			subsetClusters: map[ClusterKey]*fleetCluster{},
+			baseClusters:   map[ClusterKey]*FleetCluster{},
+			subsetClusters: map[ClusterKey]*FleetCluster{},
 			wantResult:     true,
 		},
 		{
 			name:         "Base is empty, but subset is not",
-			baseClusters: map[ClusterKey]*fleetCluster{},
-			subsetClusters: map[ClusterKey]*fleetCluster{
+			baseClusters: map[ClusterKey]*FleetCluster{},
+			subsetClusters: map[ClusterKey]*FleetCluster{
 				{"Kind1", "Name1"}: {},
 			},
 			wantResult: false,

--- a/pkg/fleet-manager/fleet_cluster.go
+++ b/pkg/fleet-manager/fleet_cluster.go
@@ -31,7 +31,7 @@ import (
 	kclient "kurator.dev/kurator/pkg/client"
 )
 
-type fleetCluster struct {
+type FleetCluster struct {
 	Secret    string
 	SecretKey string
 	client    *kclient.Client
@@ -42,10 +42,10 @@ type ClusterKey struct {
 	Name string
 }
 
-func buildFleetClusters(ctx context.Context, client client.Client, fleet *fleetapi.Fleet) (map[ClusterKey]*fleetCluster, error) {
+func buildFleetClusters(ctx context.Context, client client.Client, fleet *fleetapi.Fleet) (map[ClusterKey]*FleetCluster, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	res := make(map[ClusterKey]*fleetCluster, len(fleet.Spec.Clusters))
+	res := make(map[ClusterKey]*FleetCluster, len(fleet.Spec.Clusters))
 	for _, cluster := range fleet.Spec.Clusters {
 		clusterKey := types.NamespacedName{Namespace: fleet.Namespace, Name: cluster.Name}
 		clusterInterface, err := getFleetClusterInterface(ctx, client, cluster.Kind, clusterKey)
@@ -63,7 +63,7 @@ func buildFleetClusters(ctx context.Context, client client.Client, fleet *fleeta
 		if err != nil {
 			return nil, err
 		}
-		res[ClusterKey{Kind: cluster.Kind, Name: cluster.Name}] = &fleetCluster{
+		res[ClusterKey{Kind: cluster.Kind, Name: cluster.Name}] = &FleetCluster{
 			Secret:    clusterInterface.GetSecretName(),
 			SecretKey: clusterInterface.GetSecretKey(),
 			client:    kclient,

--- a/pkg/fleet-manager/fleet_plugin.go
+++ b/pkg/fleet-manager/fleet_plugin.go
@@ -39,7 +39,7 @@ const (
 	NoneClusterIP = "None"
 )
 
-func (f *FleetManager) reconcilePlugins(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*fleetCluster) (ctrl.Result, error) {
+func (f *FleetManager) reconcilePlugins(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*FleetCluster) (ctrl.Result, error) {
 	var resources kube.ResourceList
 
 	if fleet.Spec.Plugin != nil {
@@ -49,7 +49,7 @@ func (f *FleetManager) reconcilePlugins(ctx context.Context, fleet *fleetapi.Fle
 			err        error
 		}
 
-		type reconcileFunc func(context.Context, *fleetapi.Fleet, map[ClusterKey]*fleetCluster) (kube.ResourceList, ctrl.Result, error)
+		type reconcileFunc func(context.Context, *fleetapi.Fleet, map[ClusterKey]*FleetCluster) (kube.ResourceList, ctrl.Result, error)
 
 		funcs := []reconcileFunc{
 			f.reconcileMetricPlugin,

--- a/pkg/fleet-manager/fleet_plugin_backup.go
+++ b/pkg/fleet-manager/fleet_plugin_backup.go
@@ -51,7 +51,7 @@ const (
 
 // reconcileBackupPlugin reconciles the backup plugin configuration and installation across multiple clusters.
 // It generates and applies Velero Helm configurations based on the specified backup plugin settings in the fleet specification.
-func (f *FleetManager) reconcileBackupPlugin(ctx context.Context, fleet *v1alpha1.Fleet, fleetClusters map[ClusterKey]*fleetCluster) (kube.ResourceList, ctrl.Result, error) {
+func (f *FleetManager) reconcileBackupPlugin(ctx context.Context, fleet *v1alpha1.Fleet, fleetClusters map[ClusterKey]*FleetCluster) (kube.ResourceList, ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	veleroCfg := fleet.Spec.Plugin.Backup
@@ -203,9 +203,9 @@ func getObjStoreCredentials(ctx context.Context, client client.Client, namespace
 }
 
 // createNewSecretInFleetCluster creates a new secret in the specified fleet cluster.
-// It takes a fleetCluster instance and a pre-built corev1.Secret instance as parameters.
-// It uses the kube client from the fleetCluster instance to create the new secret in the respective cluster.
-func createNewSecretInFleetCluster(ctx context.Context, cluster *fleetCluster, newSecret *corev1.Secret) error {
+// It takes a FleetCluster instance and a pre-built corev1.Secret instance as parameters.
+// It uses the kube client from the FleetCluster instance to create the new secret in the respective cluster.
+func createNewSecretInFleetCluster(ctx context.Context, cluster *FleetCluster, newSecret *corev1.Secret) error {
 	// Get the kubeclient.Interface instance
 	kubeClient := cluster.client.CtrlRuntimeClient()
 
@@ -235,7 +235,7 @@ func createNewSecretInFleetCluster(ctx context.Context, cluster *fleetCluster, n
 }
 
 // updateNewSecretOwnerReference updates the OwnerReferences of the given secret in the specified fleet cluster.
-func (f *FleetManager) updateNewSecretOwnerReference(ctx context.Context, clusterName string, cluster *fleetCluster, newSecret *corev1.Secret) error {
+func (f *FleetManager) updateNewSecretOwnerReference(ctx context.Context, clusterName string, cluster *FleetCluster, newSecret *corev1.Secret) error {
 	// Get the kubeclient.Interface instance
 	kubeClient := cluster.client.KubeClient()
 

--- a/pkg/fleet-manager/fleet_plugin_distributedstorage.go
+++ b/pkg/fleet-manager/fleet_plugin_distributedstorage.go
@@ -26,7 +26,7 @@ import (
 	"kurator.dev/kurator/pkg/infra/util"
 )
 
-func (f *FleetManager) reconcileDistributedStoragePlugin(ctx context.Context, fleet *v1alpha1.Fleet, fleetClusters map[ClusterKey]*fleetCluster) (kube.ResourceList, ctrl.Result, error) {
+func (f *FleetManager) reconcileDistributedStoragePlugin(ctx context.Context, fleet *v1alpha1.Fleet, fleetClusters map[ClusterKey]*FleetCluster) (kube.ResourceList, ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	distributedStorageCfg := fleet.Spec.Plugin.DistributedStorage

--- a/pkg/fleet-manager/fleet_plugin_grafana.go
+++ b/pkg/fleet-manager/fleet_plugin_grafana.go
@@ -32,7 +32,7 @@ import (
 
 // reconcileGrafanaPlugin reconciles the Grafana plugin.
 // The fleetClusters parameter is currently unused, but is included to match the function signature of other functions in reconcilePlugins.
-func (f *FleetManager) reconcileGrafanaPlugin(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*fleetCluster) (kube.ResourceList, ctrl.Result, error) {
+func (f *FleetManager) reconcileGrafanaPlugin(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*FleetCluster) (kube.ResourceList, ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if fleet.Spec.Plugin.Grafana == nil {

--- a/pkg/fleet-manager/fleet_plugin_kyverno.go
+++ b/pkg/fleet-manager/fleet_plugin_kyverno.go
@@ -29,7 +29,7 @@ import (
 	"kurator.dev/kurator/pkg/infra/util"
 )
 
-func (f *FleetManager) reconcileKyvernoPlugin(ctx context.Context, fleet *fleetv1a1.Fleet, fleetClusters map[ClusterKey]*fleetCluster) (kube.ResourceList, ctrl.Result, error) {
+func (f *FleetManager) reconcileKyvernoPlugin(ctx context.Context, fleet *fleetv1a1.Fleet, fleetClusters map[ClusterKey]*FleetCluster) (kube.ResourceList, ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if fleet.Spec.Plugin.Policy == nil ||

--- a/pkg/fleet-manager/fleet_plugin_metric.go
+++ b/pkg/fleet-manager/fleet_plugin_metric.go
@@ -39,7 +39,7 @@ import (
 	"kurator.dev/kurator/pkg/infra/util"
 )
 
-func (f *FleetManager) reconcileObjStoreSecretOwnerReference(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*fleetCluster) error {
+func (f *FleetManager) reconcileObjStoreSecretOwnerReference(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*FleetCluster) error {
 	for _, cluster := range fleet.Spec.Clusters {
 		fleetCluster, ok := fleetClusters[ClusterKey{cluster.Kind, cluster.Name}]
 		if !ok {
@@ -77,7 +77,7 @@ func (f *FleetManager) reconcileObjStoreSecretOwnerReference(ctx context.Context
 
 // reconcileSidecarRemoteService reconciles a headless service named thanos-sidecar-remote, and ensure owner reference is set for all resources
 // TODO: find a better way to collect service endpoints of thanos-sidecar-remote service after all helm releases are reconciled
-func (f *FleetManager) reconcileSidecarRemoteService(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*fleetCluster) error {
+func (f *FleetManager) reconcileSidecarRemoteService(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*FleetCluster) error {
 	log := ctrl.LoggerFrom(ctx)
 	log = log.WithValues("fleet", types.NamespacedName{Name: fleet.Name, Namespace: fleet.Namespace})
 
@@ -198,7 +198,7 @@ func (f *FleetManager) reconcileSidecarRemoteService(ctx context.Context, fleet 
 }
 
 // syncObjStoreSecret syncs the secret to the cluster
-func (f *FleetManager) syncObjStoreSecret(ctx context.Context, fleetCluster *fleetCluster, secret *corev1.Secret) error {
+func (f *FleetManager) syncObjStoreSecret(ctx context.Context, fleetCluster *FleetCluster, secret *corev1.Secret) error {
 	_, err := fleetCluster.client.KubeClient().CoreV1().Namespaces().Get(ctx, secret.Namespace, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err := fleetCluster.client.KubeClient().CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
@@ -232,7 +232,7 @@ func (f *FleetManager) syncObjStoreSecret(ctx context.Context, fleetCluster *fle
 	return nil
 }
 
-func (f *FleetManager) reconcileMetricPlugin(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*fleetCluster) (kube.ResourceList, ctrl.Result, error) {
+func (f *FleetManager) reconcileMetricPlugin(ctx context.Context, fleet *fleetapi.Fleet, fleetClusters map[ClusterKey]*FleetCluster) (kube.ResourceList, ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if fleet.Spec.Plugin.Metric == nil {

--- a/pkg/fleet-manager/migrate_controller.go
+++ b/pkg/fleet-manager/migrate_controller.go
@@ -116,7 +116,7 @@ func (m *MigrateManager) reconcileMigrateBackup(ctx context.Context, migrate *ba
 		return ctrl.Result{}, fmt.Errorf("fetching source cluster: %w", err)
 	}
 	var sourceClusterKey ClusterKey
-	var sourceClusterAccess *fleetCluster
+	var sourceClusterAccess *FleetCluster
 	// "migrate.Spec.SourceCluster" must contain one clusters, it is ensured by admission webhook
 	for key, value := range fleetClusters {
 		sourceClusterKey = key

--- a/pkg/fleet-manager/restore_controller.go
+++ b/pkg/fleet-manager/restore_controller.go
@@ -130,7 +130,7 @@ func (r *RestoreManager) reconcileRestore(ctx context.Context, restore *backupap
 var ErrNoCompletedBackups = errors.New("No completed Velero backups available for restore.")
 
 // reconcileRestoreResources converts the restore resources into velero restore resources on the target clusters, and applies those velero restore resources.
-func (r *RestoreManager) reconcileRestoreResources(ctx context.Context, restore *backupapi.Restore, referredBackup *backupapi.Backup, destinationClusters map[ClusterKey]*fleetCluster, fleetName string) (ctrl.Result, error) {
+func (r *RestoreManager) reconcileRestoreResources(ctx context.Context, restore *backupapi.Restore, referredBackup *backupapi.Backup, destinationClusters map[ClusterKey]*FleetCluster, fleetName string) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	restoreLabels := generateVeleroInstanceLabel(RestoreNameLabel, restore.Name, fleetName)
@@ -197,7 +197,7 @@ func (r *RestoreManager) reconcileDeleteRestore(ctx context.Context, restore *ba
 // getBackupForRestore retrieves the name of the Velero backup associated with the provided restore.
 // If the referred backup is an immediate backup, it returns the generated Velero backup name.
 // If the referred backup is a scheduled backup, it fetches the name of the most recent completed backup.
-func (r *RestoreManager) getBackupForRestore(ctx context.Context, restore *backupapi.Restore, referredBackup *backupapi.Backup, clusterAccess *fleetCluster, clusterName, creatorKind, creatorNamespace, creatorName string) (string, error) {
+func (r *RestoreManager) getBackupForRestore(ctx context.Context, restore *backupapi.Restore, referredBackup *backupapi.Backup, clusterAccess *FleetCluster, clusterName, creatorKind, creatorNamespace, creatorName string) (string, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	veleroScheduleName := generateVeleroResourceName(clusterName, BackupKind, referredBackup.Namespace, referredBackup.Name)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

the `fleetCluster` struct is used in many controller,
if we want reactor the  `fleet-manager` folder, we have to make it public.
see #481 