### PR TITLE
Adding Security Policies to the Repository

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Report a vulnerability
+
+We sincerely request you to keep the vulnerability information confidential and responsibly disclose the vulnerabilities.
+
+To report a vulnerability, please contact the Security Team: [kurator-security@googlegroups.com](mailto:kurator-security@googlegroups.com). You can email the Security Team with the security details and the details expected for [Kurator vulnerability reports](https://github.com/kurator-dev/kurator/tree/main/community/security/comms-templates/vulnerability-report-template.md).
+
+### E-mail Response
+
+The team will help diagnose the severity of the issue and determine how to address the issue. The reporter(s) can expect a response within 2 business day acknowledging the issue was received. If a response is not received within 2 business day, please reach out to any Security Team member directly to confirm receipt of the issue. We’ll try to keep you informed about our progress throughout the process.
+
+### When Should I Report a Vulnerability?
+
+- You think you discovered a potential security vulnerability in Kurator
+- You are unsure how a vulnerability affects Kurator
+
+### When Should I NOT Report a Vulnerability?
+
+- You need help tuning Kurator components for security
+- You need help applying security related updates
+- Your issue is not security related
+
+If you think you discovered a vulnerability in another project that Kurator depends on, and that project has their own vulnerability reporting and disclosure process, please report it directly there.
+
+## Security release process
+
+The Kurator community will strictly handle the reporting vulnerability according to this [procedure](https://github.com/kurator-dev/kurator/tree/main/community/security/security-release-process.md).
+
+## Relative Mailing lists
+
+- [kurator-security@googlegroups.com](mailto:kurator-security@googlegroups.com), is for reporting security concerns to the Kurator Security Team, who uses the list to privately discuss security issues and fixes prior to disclosure.
+
+- [kurator-security@googlegroups.com](mailto:kurator-security@googlegroups.com), is for advance private information and vulnerability disclosure.
+
+More details of group membership is managed [here](https://github.com/kurator-dev/kurator/tree/main/community/security/security-groups.md).
+
+See the [private-distributors-list](https://github.com/kurator-dev/kurator/tree/main/community/security/private-distributors-list.md) for information on how Kurator distributors or vendors can apply to join this list.
+
+## Supported versions
+
+Kurator versions are expressed as x.y.z, where x is the major version, y is the minor version, and z is the patch version, following [Semantic Versioning](https://semver.org/) terminology.
+
+The Kurator project maintains release branches for the most recent three minor releases. Applicable fixes, including security fixes, may be backported to those three release branches, depending on severity and feasibility.
+
+Our typical patch release cadence is every 3 months. Critical bug fixes may cause a more immediate release outside of the normal cadence. We also aim to not make releases during major holiday periods.
+
+See the [Kurator releases page](https://github.com/kurator-dev/kurator/releases) for information on supported versions of Kurator.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Kurator Repository doesn't have a security policy as of yet. For the health of the project, we need add a SECURITY.md
**Which issue(s) this PR fixes**:
Fixes # #487 

