### PR TITLE
add Semantic Versioning Specification in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,21 @@ Kurator is under the Apache 2.0 license. See the [LICENSE](LICENSE) file for det
 ## report a vulnerability
 
 If you find a vulnerability in Kurator, you can report it to our security-team in the [following way](https://github.com/kurator-dev/kurator/blob/main/community/security/report-a-vulnerability.md). We will deal with it as soon as possible.
+
+## Semantic Versioning Specification
+
+1.A normal version number MUST take the form X.Y.Z where X, Y, and Z are non-negative integers, and MUST NOT contain leading zeroes. X is the major version, Y is the minor version, and Z is the patch version. Each element MUST increase numerically. For instance: 1.9.0 -> 1.10.0 -> 1.11.0.
+
+2.Once a versioned package has been released, the contents of that version MUST NOT be modified. Any modifications MUST be released as a new version. Once a package is released with a version number of x.y.z, it is considered stable.
+
+3.Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.
+
+4.Version 1.0.0 defines the public API. The way in which the version number is incremented after this release is dependent on this public API and how it changes.
+
+5.Patch version Z (x.y.Z | x > 0) MUST be incremented if only backward compatible bug fixes are introduced. A bug fix is defined as an internal change that fixes incorrect behavior.
+
+6.Minor version Y (x.Y.z | x > 0) MUST be incremented if new, backward compatible functionality is introduced to the public API. It MUST be incremented if any public API functionality is marked as deprecated. It MAY be incremented if substantial new functionality or improvements are introduced within the private code. It MAY include patch level changes. Patch version MUST be reset to 0 when minor version is incremented.
+
+7.Major version X (X.y.z | X > 0) MUST be incremented if any backward incompatible changes are introduced to the public API. It MAY also include minor and patch level changes. Patch and minor versions MUST be reset to 0 when major version is incremented.
+
+8.A pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers immediately following the patch version. Identifiers MUST comprise only ASCII alphanumerics and hyphens [0-9A-Za-z-]. Identifiers MUST NOT be empty. Numeric identifiers MUST NOT include leading zeroes. Pre-release versions have a lower precedence than the associated normal version. A pre-release version indicates that the version is unstable and might not satisfy the intended compatibility requirements as denoted by its associated normal version. Examples: 0.5.0-rc.0


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
**What this PR does / why we need it**:
Establishes a specification that Kurator release version numbers should follow.

