### PR TITLE
add a community membership guidelines

### DIFF
--- a/community/membership/community-membership.md
+++ b/community/membership/community-membership.md
@@ -8,14 +8,15 @@ reviewing issues/PRs.
 ### Requirements
 
 - Sponsor from 2 reviewers
-- Enabled [two-factor authentication] on their GitHub account
-- Actively contributed to the community. Contributions may include, but are not limited to:
+- Enabled [two-factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication) on their GitHub account
+- Actively contributed to Kurator. Contributions may include, but are not limited to:
     - Authoring PRs.
     - Reviewing issues/PRs authored by other community members.
     - Participating in community discussions on [slack/mailing list](https://github.com/kurator-dev/kurator/blob/main/README.md#contact).
     - Participate in Kurator community meetings.(We don't have it now, but will provide it later)
+- Have read the [contributor guide](https://github.com/kurator-dev/kurator/blob/main/CONTRIBUTING.md)
 - Have your sponsoring reviewers reply confirmation of sponsorship: +1
-- Once your sponsors have responded, your request will be reviewed by the org owners
+- Once your sponsors have responded, your request will be reviewed by the `Kurator Github Admin Team`
 
 **Note:** Record the PR number of your author and the PR number of the review. We will ask you to provide proof of this when you apply to become a member of the community.
 
@@ -25,6 +26,8 @@ reviewing issues/PRs.
 - Can be assigned to issues and PRs and community members can also request their review.
 - Participate in assigned issues and PRs.
 - Welcome new contributors.
+- They can be assigned to issues and PRs.
+- Members can do `/lgtm` on open PRs.
 - Guide new contributors to relevant docs/files.
 - Help/Motivate new members in contributing to Kurator.
 
@@ -47,7 +50,7 @@ They are knowledgeable about both the codebase and software engineering principl
 - Responsible for project quality control
 - Focus on code quality and correctness, including testing and refactoring
 - May also review for more holistic issues, but not a requirement
-- Expected to be responsive to review requests, add `lgtm` label to reviewed PRs
+- May get a badge on PR and issue comments.
 
 ## Approver
 
@@ -56,10 +59,11 @@ Has overall knowledge of the project and features in the project.
 
 ### Requirements
 
-- Sponsor from 2 owners
+- Deep understanding of the technical goals and direction of the project.
+- Deep understanding of the technical domain (specifically the language) of the project.
 - Approver for at least 2 months
-- Nominated by a project owner
 - Good technical judgement in feature design/development
+- Pass super-majority(two-thirds/ 66.66%) vote.
 
 ### Responsibilities and privileges
 

--- a/community/membership/community-membership.md
+++ b/community/membership/community-membership.md
@@ -12,7 +12,7 @@ reviewing issues/PRs.
 - Actively contributed to the community. Contributions may include, but are not limited to:
     - Authoring PRs.
     - Reviewing issues/PRs authored by other community members.
-    - Participating in community discussions on slack/mailing list.(We don't have it now, but will provide it later)
+    - Participating in community discussions on [slack/mailing list](https://github.com/kurator-dev/kurator/blob/main/README.md#contact).
     - Participate in Kurator community meetings.(We don't have it now, but will provide it later)
 - Have your sponsoring reviewers reply confirmation of sponsorship: +1
 - Once your sponsors have responded, your request will be reviewed by the org owners

--- a/community/membership/community-membership.md
+++ b/community/membership/community-membership.md
@@ -49,9 +49,9 @@ They are knowledgeable about both the codebase and software engineering principl
 - May also review for more holistic issues, but not a requirement
 - Expected to be responsive to review requests, add `lgtm` label to reviewed PRs
 
-## Maintainer
+## Approver
 
-Maintainers are approvers who have shown good technical judgement in feature design/development in the past.
+Approvers have shown good technical judgement in feature design/development in the past.
 Has overall knowledge of the project and features in the project.
 
 ### Requirements
@@ -68,9 +68,9 @@ Has overall knowledge of the project and features in the project.
 - Ensure API compatibility with forward/backward versions based on feature graduation criteria
 - Analyze and propose new features/enhancements in Kurator project
 - Demonstrate sound technical judgement
-- Mentor contributors and approvers
+- Mentor contributors and other approvers
 - Have top level write access to relevant repository (able click Merge PR button when manual check-in is necessary)
-- Name entry in Maintainers file of the repository
+- Name entry in Approvers file of the repository
 - Participate & Drive design/development of multiple features
 
 ## Inactive members

--- a/community/membership/community-membership.md
+++ b/community/membership/community-membership.md
@@ -1,0 +1,49 @@
+## Member
+
+Members are active participants in the community who contribute by authoring PRs,
+reviewing issues/PRs.
+
+**Note:** If you meet the following requirements, welcome to open an issue and apply to become a Kurator Organization member!
+
+### Requirements
+
+- Sponsor from 2 reviewers
+- Enabled [two-factor authentication] on their GitHub account
+- Actively contributed to the community. Contributions may include, but are not limited to:
+    - Authoring PRs.
+    - Reviewing issues/PRs authored by other community members.
+    - Participating in community discussions on slack/mailing list.(We don't have it now, but will provide it later)
+    - Participate in Kurator community meetings.(We don't have it now, but will provide it later)
+- Have your sponsoring reviewers reply confirmation of sponsorship: +1
+- Once your sponsors have responded, your request will be reviewed by the org owners
+
+**Note:** Record the PR number of your author and the PR number of the review. We will ask you to provide proof of this when you apply to become a member of the community.
+
+### Responsibilities and privileges
+
+- Member of the Kurator GitHub organization.
+- Can be assigned to issues and PRs and community members can also request their review.
+- Participate in assigned issues and PRs.
+- Welcome new contributors.
+- Guide new contributors to relevant docs/files.
+- Help/Motivate new members in contributing to Kurator.
+
+## Inactive members
+
+_Members are continuously active contributors in the community._
+
+A core principle in maintaining a healthy community is encouraging active
+participation. It is inevitable that people's focuses will change over time and
+they are not expected to be actively contributing forever.
+
+Therefore members with an extended period away from the project with no activity
+will emeritus or be removed from the Kurator GitHub Organizations and will be required to go through the org membership process again after re-familiarizing themselves with the current state.
+
+### How inactivity is measured
+
+Inactive members are defined as members of one of the Kurator Organizations
+with **no** contributions across any organization within 12 months.
+
+After an extended period away from the project with no activity
+those members would need to re-familiarize themselves with the current state
+before being able to contribute effectively.

--- a/community/membership/community-membership.md
+++ b/community/membership/community-membership.md
@@ -28,6 +28,51 @@ reviewing issues/PRs.
 - Guide new contributors to relevant docs/files.
 - Help/Motivate new members in contributing to Kurator.
 
+## Reviewer
+
+Reviewers are able to review code for quality and correctness on some part of a subproject.
+They are knowledgeable about both the codebase and software engineering principles.
+
+### Requirements
+
+- member for at least 1 months
+- Primary reviewer for at least 5 PRs to the codebase
+- Reviewed or merged at least 20 substantial PRs to the codebase
+- Knowledgeable about the codebase
+- May either self-nominate,  or be nominated by an approver
+
+### Responsibilities and privileges
+
+- Code reviewer status may be a precondition to accepting large code contributions
+- Responsible for project quality control
+- Focus on code quality and correctness, including testing and refactoring
+- May also review for more holistic issues, but not a requirement
+- Expected to be responsive to review requests, add `lgtm` label to reviewed PRs
+
+## Maintainer
+
+Maintainers are approvers who have shown good technical judgement in feature design/development in the past.
+Has overall knowledge of the project and features in the project.
+
+### Requirements
+
+- Sponsor from 2 owners
+- Approver for at least 2 months
+- Nominated by a project owner
+- Good technical judgement in feature design/development
+
+### Responsibilities and privileges
+
+- Participate in release planning
+- Maintain project code quality
+- Ensure API compatibility with forward/backward versions based on feature graduation criteria
+- Analyze and propose new features/enhancements in Kurator project
+- Demonstrate sound technical judgement
+- Mentor contributors and approvers
+- Have top level write access to relevant repository (able click Merge PR button when manual check-in is necessary)
+- Name entry in Maintainers file of the repository
+- Participate & Drive design/development of multiple features
+
 ## Inactive members
 
 _Members are continuously active contributors in the community._

--- a/community/membership/community-membership.md
+++ b/community/membership/community-membership.md
@@ -59,23 +59,19 @@ Has overall knowledge of the project and features in the project.
 
 ### Requirements
 
-- Deep understanding of the technical goals and direction of the project.
-- Deep understanding of the technical domain (specifically the language) of the project.
-- Approver for at least 2 months
-- Good technical judgement in feature design/development
-- Pass super-majority(two-thirds/ 66.66%) vote.
+- Reviewer of the codebase for at least 1 months.
+- Primary reviewer for at least 10 substantial PRs to the codebase.
+- Reviewed or merged at least 30 PRs to the codebase.
+- Have good codebase knowledge.
 
 ### Responsibilities and privileges
 
-- Participate in release planning
-- Maintain project code quality
-- Ensure API compatibility with forward/backward versions based on feature graduation criteria
-- Analyze and propose new features/enhancements in Kurator project
-- Demonstrate sound technical judgement
-- Mentor contributors and other approvers
-- Have top level write access to relevant repository (able click Merge PR button when manual check-in is necessary)
-- Name entry in Approvers file of the repository
-- Participate & Drive design/development of multiple features
+- Review code to maintain/improve code quality.
+- Expected to be responsive to review requests.
+- Acknowledge and work on review requests from community members.
+- May approve code contributions for acceptance related to relevant expertise.
+- Have 'write access' to specific packages inside a repo, enforced via bot.
+- Continue to contribute and guide other community members to contribute in Kurator project.
 
 ## Inactive members
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
**What this PR does / why we need it**:
Provides criteria for what can be applied for as a member of the kurator community and what kind of circumstances would result in the revocation of kurator community membership.
**Which issue(s) this PR fixes**:
Fixes # #499 


