### PR TITLE
Changed the float to string in the CanaryThresholdRange

### DIFF
--- a/docs/proposals/rollout/rollout.md
+++ b/docs/proposals/rollout/rollout.md
@@ -417,11 +417,11 @@ type Metric struct {
 type CanaryThresholdRange struct {
     // Minimum value
     // +optional
-    Min *float64 `json:"min,omitempty"`
+    Min string `json:"min,omitempty"`
 
     // Maximum value
     // +optional
-    Max *float64 `json:"max,omitempty"`
+    Max string `json:"max,omitempty"`
 }
 
 // CrossNamespaceObjectReference contains enough information to let you locate the


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
**What this PR does / why we need it**:
The usage of float is highly discouraged, as support for them varies across languages. So serializing float as string instead.
Modified proposal to be consistent with the actual api.
