### PR TITLE
update readme for fix markdown lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It provides powerful capabilities for multi-cloud and multi-cluster management, 
 ## Architecture
 
 <div  align="center">
-    <img src="./docs/images/kurator-arch.svg" width = "80%" align="center">
+    <img src="./docs/images/kurator-arch.svg" width="80%" alt="Kurator architecture diagram" align="center">
 </div>
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ It provides powerful capabilities for multi-cloud and multi-cluster management, 
 
 ## Architecture
 
-<div  align="center">
-    <img src="./docs/images/kurator-arch.svg" width="80%" alt="Kurator architecture diagram" align="center">
-</div>
+![Kurator architecture diagram](./docs/images/kurator-arch.svg)
 
 ## Documentation
 


### PR DESCRIPTION
**What type of PR is this?**


/kind bug
/kind documentation

**What this PR does / why we need it**:

fixed markdown lint error by adding missing alternate text for images.

see
```
markdownlint docs --ignore docs/content/en/references --ignore docs/node_modules -c common/config/mdl.json
markdownlint ./README.md -c common/config/mdl.json
./README.md:33:5 MD045/no-alt-text Images should have alternate text (alt text)
```