### PR TITLE
pipeline: complete pipeline list cli

### DIFF
--- a/cmd/kurator/app/app.go
+++ b/cmd/kurator/app/app.go
@@ -24,6 +24,7 @@ import (
 
 	"kurator.dev/kurator/cmd/kurator/app/install"
 	"kurator.dev/kurator/cmd/kurator/app/join"
+	"kurator.dev/kurator/cmd/kurator/app/pipeline"
 	"kurator.dev/kurator/cmd/kurator/app/tool"
 	"kurator.dev/kurator/cmd/kurator/app/version"
 	"kurator.dev/kurator/pkg/generic"
@@ -53,6 +54,7 @@ func NewKuratorCommand() *cobra.Command {
 	cmd.AddCommand(install.NewCmd(o))
 	cmd.AddCommand(join.NewCmd(o))
 	cmd.AddCommand(tool.NewCmd(o))
+	cmd.AddCommand(pipeline.NewCmd(o))
 
 	return cmd
 }

--- a/cmd/kurator/app/pipeline/execution/execution.go
+++ b/cmd/kurator/app/pipeline/execution/execution.go
@@ -1,0 +1,39 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package execution
+
+import (
+	"github.com/spf13/cobra"
+
+	"kurator.dev/kurator/cmd/kurator/app/pipeline/execution/list"
+	"kurator.dev/kurator/pkg/generic"
+)
+
+func NewCmd(opts *generic.Options) *cobra.Command {
+	joinCmd := &cobra.Command{
+		Use:                   "execution",
+		Short:                 "manage kurator pipeline execution",
+		DisableFlagsInUseLine: true,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
+	}
+
+	joinCmd.AddCommand(list.NewCmd(opts))
+
+	return joinCmd
+}

--- a/cmd/kurator/app/pipeline/execution/execution.go
+++ b/cmd/kurator/app/pipeline/execution/execution.go
@@ -24,7 +24,7 @@ import (
 )
 
 func NewCmd(opts *generic.Options) *cobra.Command {
-	joinCmd := &cobra.Command{
+	executionCmd := &cobra.Command{
 		Use:                   "execution",
 		Short:                 "manage kurator pipeline execution",
 		DisableFlagsInUseLine: true,
@@ -33,7 +33,7 @@ func NewCmd(opts *generic.Options) *cobra.Command {
 		},
 	}
 
-	joinCmd.AddCommand(list.NewCmd(opts))
+	executionCmd.AddCommand(list.NewCmd(opts))
 
-	return joinCmd
+	return executionCmd
 }

--- a/cmd/kurator/app/pipeline/execution/list/list.go
+++ b/cmd/kurator/app/pipeline/execution/list/list.go
@@ -26,10 +26,9 @@ import (
 	"kurator.dev/kurator/pkg/pipeline/execution/list"
 )
 
-var Args = list.Args{}
-
 func NewCmd(opts *generic.Options) *cobra.Command {
-	PipelineListCmd := &cobra.Command{
+	var Args = list.Args{}
+	listCmd := &cobra.Command{
 		Use:     "list",
 		Short:   "list the kurator pipeline execution",
 		Example: getExample(),
@@ -50,18 +49,20 @@ func NewCmd(opts *generic.Options) *cobra.Command {
 		},
 	}
 
-	PipelineListCmd.PersistentFlags().StringVarP(&Args.Namespace, "namespace", "n", "default", "specific namespace")
-	PipelineListCmd.PersistentFlags().BoolVarP(&Args.AllNamespaces, "all-namespaces", "A", false, "If true, list the pipelineRuns across all namespaces")
+	listCmd.PersistentFlags().StringVarP(&Args.Namespace, "namespace", "n", "default", "specific namespace")
+	listCmd.PersistentFlags().BoolVarP(&Args.AllNamespaces, "all-namespaces", "A", false, "If true, list the pipelineRuns across all namespaces")
 
-	return PipelineListCmd
+	return listCmd
 }
 
 func getExample() string {
 	return `  # List kurator pipeline objects in the default namespace
-  kurator pipeline list
+  kurator pipeline execution list
+
   # List the pipelines in a specific namespace (replace 'example-namespace' with your namespace)
-  kurator pipeline list -n example-namespace
+  kurator pipeline execution list -n example-namespace
+
   # List the pipelines across all namespaces
-  kurator pipeline list -A
+  kurator pipeline execution list -A
 `
 }

--- a/cmd/kurator/app/pipeline/execution/list/list.go
+++ b/cmd/kurator/app/pipeline/execution/list/list.go
@@ -1,0 +1,67 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"kurator.dev/kurator/pkg/generic"
+	"kurator.dev/kurator/pkg/pipeline/execution/list"
+)
+
+var Args = list.Args{}
+
+func NewCmd(opts *generic.Options) *cobra.Command {
+	PipelineListCmd := &cobra.Command{
+		Use:     "list",
+		Short:   "list the kurator pipeline execution",
+		Example: getExample(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			PipelineList, err := list.NewPipelineList(opts, &Args)
+			if err != nil {
+				logrus.Errorf("pipeline init error: %v", err)
+				return fmt.Errorf("pipeline init error: %v", err)
+			}
+
+			logrus.Debugf("start list pipeline obj, Global: %+v ", opts)
+			if err := PipelineList.ListExecute(); err != nil {
+				logrus.Errorf("pipeline execute error: %v", err)
+				return fmt.Errorf("pipeline execute error: %v", err)
+			}
+
+			return nil
+		},
+	}
+
+	PipelineListCmd.PersistentFlags().StringVarP(&Args.Namespace, "namespace", "n", "default", "specific namespace")
+	PipelineListCmd.PersistentFlags().BoolVarP(&Args.AllNamespaces, "all-namespaces", "A", false, "If true, list the pipelineRuns across all namespaces")
+
+	return PipelineListCmd
+}
+
+func getExample() string {
+	return `  # List kurator pipeline objects in the default namespace
+  kurator pipeline list
+  # List the pipelines in a specific namespace (replace 'example-namespace' with your namespace)
+  kurator pipeline list -n example-namespace
+  # List the pipelines across all namespaces
+  kurator pipeline list -A
+`
+}

--- a/cmd/kurator/app/pipeline/pipeline.go
+++ b/cmd/kurator/app/pipeline/pipeline.go
@@ -1,0 +1,39 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"github.com/spf13/cobra"
+
+	"kurator.dev/kurator/cmd/kurator/app/pipeline/execution"
+	"kurator.dev/kurator/pkg/generic"
+)
+
+func NewCmd(opts *generic.Options) *cobra.Command {
+	joinCmd := &cobra.Command{
+		Use:                   "pipeline",
+		Short:                 "manage kurator pipeline",
+		DisableFlagsInUseLine: true,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
+	}
+
+	joinCmd.AddCommand(execution.NewCmd(opts))
+
+	return joinCmd
+}

--- a/cmd/kurator/app/pipeline/pipeline.go
+++ b/cmd/kurator/app/pipeline/pipeline.go
@@ -24,7 +24,7 @@ import (
 )
 
 func NewCmd(opts *generic.Options) *cobra.Command {
-	joinCmd := &cobra.Command{
+	pipelineCmd := &cobra.Command{
 		Use:                   "pipeline",
 		Short:                 "manage kurator pipeline",
 		DisableFlagsInUseLine: true,
@@ -33,7 +33,7 @@ func NewCmd(opts *generic.Options) *cobra.Command {
 		},
 	}
 
-	joinCmd.AddCommand(execution.NewCmd(opts))
+	pipelineCmd.AddCommand(execution.NewCmd(opts))
 
-	return joinCmd
+	return pipelineCmd
 }

--- a/pkg/pipeline/execution/list/list.go
+++ b/pkg/pipeline/execution/list/list.go
@@ -1,0 +1,130 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+
+	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"kurator.dev/kurator/pkg/client"
+	"kurator.dev/kurator/pkg/generic"
+)
+
+// pipelineList is the structure used for listing pipeline objects.
+type pipelineList struct {
+	*client.Client
+	args    *Args
+	options *generic.Options
+}
+
+// Args holds the arguments for listing pipeline runs.
+type Args struct {
+	Namespace     string // Specific namespace to list pipeline runs.
+	AllNamespaces bool   // Flag to list pipeline runs across all namespaces.
+}
+
+// NewPipelineList creates a new pipelineList instance.
+func NewPipelineList(opts *generic.Options, args *Args) (*pipelineList, error) {
+	pList := &pipelineList{
+		options: opts,
+		args:    args,
+	}
+	rest := opts.RESTClientGetter()
+	c, err := client.NewClient(rest)
+	if err != nil {
+		return nil, err
+	}
+	pList.Client = c
+	return pList, nil
+}
+
+// PipelineRunValue represents a single pipeline run.
+type PipelineRunValue struct {
+	Name              string
+	CreationTimestamp metav1.Time
+	Namespace         string
+	CreatorPipeline   string
+}
+
+// ListExecute fetches and displays a formatted list of PipelineRuns.
+func (p *pipelineList) ListExecute() error {
+	listOpts := &ctrlclient.ListOptions{}
+
+	// Apply namespace filter if AllNamespaces flag is not set.
+	if !p.args.AllNamespaces {
+		listOpts.Namespace = p.args.Namespace
+	}
+
+	pipelineRunList := &tektonapi.PipelineRunList{}
+	if err := p.CtrlRuntimeClient().List(context.Background(), pipelineRunList, listOpts); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get PipelineRunList: %v\n", err)
+		return err
+	}
+
+	// Transform pipelineRunList items to PipelineRunValue instances.
+	var valueList []PipelineRunValue
+	for _, tr := range pipelineRunList.Items {
+		valueList = append(valueList, PipelineRunValue{
+			Name:              tr.Name,
+			CreationTimestamp: tr.CreationTimestamp,
+			Namespace:         tr.Namespace,
+			CreatorPipeline:   tr.Spec.PipelineRef.Name,
+		})
+	}
+
+	// Group and sort pipeline runs for display.
+	groupedRuns := GroupAndSortPipelineRuns(valueList)
+
+	fmt.Println("------------------------------------- Pipeline Execution -----------------------------")
+	fmt.Println("  Execution Name          |   Creation Time     |   Namespace      | Creator Pipeline")
+	fmt.Println("--------------------------------------------------------------------------------------")
+
+	for _, runs := range groupedRuns {
+		for _, tr := range runs {
+			fmt.Printf("%-25s | %-20s | %-16s | %s\n",
+				tr.Name,
+				tr.CreationTimestamp.Time.Format("2006-01-02 15:04:05"),
+				tr.Namespace,
+				tr.CreatorPipeline)
+		}
+	}
+
+	return nil
+}
+
+// GroupAndSortPipelineRuns organizes PipelineRunValues by CreatorPipeline and orders them by CreationTimestamp within each group.
+func GroupAndSortPipelineRuns(runs []PipelineRunValue) map[string][]PipelineRunValue {
+	groups := make(map[string][]PipelineRunValue)
+	for _, run := range runs {
+		groups[run.CreatorPipeline] = append(groups[run.CreatorPipeline], run)
+	}
+
+	// Sort each group by creation timestamp.
+	for _, group := range groups {
+		sort.Slice(group, func(i, j int) bool {
+			return group[i].CreationTimestamp.Time.Before(group[j].CreationTimestamp.Time)
+		})
+	}
+
+	return groups
+}

--- a/pkg/pipeline/execution/list/list.go
+++ b/pkg/pipeline/execution/list/list.go
@@ -19,9 +19,9 @@ package list
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 
+	"github.com/sirupsen/logrus"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -77,7 +77,7 @@ func (p *pipelineList) ListExecute() error {
 
 	pipelineRunList := &tektonapi.PipelineRunList{}
 	if err := p.CtrlRuntimeClient().List(context.Background(), pipelineRunList, listOpts); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get PipelineRunList: %v\n", err)
+		logrus.Errorf("failed to get PipelineRunList, %v", err)
 		return err
 	}
 

--- a/pkg/pipeline/execution/list/list_test.go
+++ b/pkg/pipeline/execution/list/list_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestGroupAndSortPipelineRuns tests the GroupAndSortPipelineRuns function.
+func TestGroupAndSortPipelineRuns(t *testing.T) {
+	tests := []struct {
+		name     string
+		runs     []PipelineRunValue
+		expected map[string][]PipelineRunValue
+	}{
+		{
+			name: "Group and sort pipeline runs",
+			runs: []PipelineRunValue{
+				{
+					Name:              "run1",
+					CreationTimestamp: metav1.Time{Time: time.Date(2024, 01, 02, 10, 00, 00, 00, time.UTC)},
+					Namespace:         "ns1",
+					CreatorPipeline:   "pipeline1",
+				},
+				{
+					Name:              "run2",
+					CreationTimestamp: metav1.Time{Time: time.Date(2024, 01, 02, 12, 00, 00, 00, time.UTC)},
+					Namespace:         "ns2",
+					CreatorPipeline:   "pipeline2",
+				},
+				{
+					Name:              "run3",
+					CreationTimestamp: metav1.Time{Time: time.Date(2024, 01, 02, 11, 00, 00, 00, time.UTC)},
+					Namespace:         "ns1",
+					CreatorPipeline:   "pipeline1",
+				},
+			},
+			expected: map[string][]PipelineRunValue{
+				"pipeline1": {
+					{
+						Name:              "run1",
+						CreationTimestamp: metav1.Time{Time: time.Date(2024, 01, 02, 10, 00, 00, 00, time.UTC)},
+						Namespace:         "ns1",
+						CreatorPipeline:   "pipeline1",
+					},
+					{
+						Name:              "run3",
+						CreationTimestamp: metav1.Time{Time: time.Date(2024, 01, 02, 11, 00, 00, 00, time.UTC)},
+						Namespace:         "ns1",
+						CreatorPipeline:   "pipeline1",
+					},
+				},
+				"pipeline2": {
+					{
+						Name:              "run2",
+						CreationTimestamp: metav1.Time{Time: time.Date(2024, 01, 02, 12, 00, 00, 00, time.UTC)},
+						Namespace:         "ns2",
+						CreatorPipeline:   "pipeline2",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GroupAndSortPipelineRuns(tt.runs)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

part of #533

here shows how to use it 

```console
root@xql:~/go/src/kurator.dev/kurator# kurator pipeline execution list -h
list the kurator pipeline execution

Usage:
  kurator pipeline execution list [flags]

Examples:
  # List kurator pipeline objects in the default namespace
  kurator pipeline execution list

  # List the pipelines in a specific namespace (replace 'example-namespace' with your namespace)
  kurator pipeline execution list -n example-namespace

  # List the pipelines across all namespaces
  kurator pipeline execution list -A

Flags:
  -A, --all-namespaces     If true, list the pipelineRuns across all namespaces
  -h, --help               help for list
  -n, --namespace string   specific namespace (default "default")

Global Flags:
      --context string           name of the kubeconfig context to use
      --dry-run                  console/log output only, make no changes.
      --home-dir string          install path, default to $HOME/.kurator (default "/root/.kurator")
  -c, --kubeconfig string        path to the kubeconfig file, default to karmada apiserver config (default "/etc/karmada/karmada-apiserver.config")
      --wait-interval duration   interval used for checking pod ready, default value is 1s. (default 1s)
      --wait-timeout duration    timeout used for checking pod ready, default value is 2m. (default 2m0s)
root@xql:~/go/src/kurator.dev/kurator# kurator pipeline execution list --kubeconfig /root/.kube/kurator-host.config
------------------------------------- Pipeline Execution -----------------------------
  Execution Name          |   Creation Time     |   Namespace      | Creator Pipeline
--------------------------------------------------------------------------------------
root@xql:~/go/src/kurator.dev/kurator# kurator pipeline execution list --kubeconfig /root/.kube/kurator-host.config -n kurator-pipeline
------------------------------------- Pipeline Execution -----------------------------
  Execution Name          |   Creation Time     |   Namespace      | Creator Pipeline
--------------------------------------------------------------------------------------
quick-start-run-frb7l     | 2023-12-26 16:59:55  | kurator-pipeline | quick-start
quick-start-run-h65wx     | 2023-12-29 16:14:07  | kurator-pipeline | quick-start
root@xql:~/go/src/kurator.dev/kurator# kurator pipeline execution list --kubeconfig /root/.kube/kurator-host.config -n test-ns
------------------------------------- Pipeline Execution -----------------------------
  Execution Name          |   Creation Time     |   Namespace      | Creator Pipeline
--------------------------------------------------------------------------------------
root@xql:~/go/src/kurator.dev/kurator# kurator pipeline execution list --kubeconfig /root/.kube/kurator-host.config -A
------------------------------------- Pipeline Execution -----------------------------
  Execution Name          |   Creation Time     |   Namespace      | Creator Pipeline
--------------------------------------------------------------------------------------
quick-start-run-frb7l     | 2023-12-26 16:59:55  | kurator-pipeline | quick-start
quick-start-run-h65wx     | 2023-12-29 16:14:07  | kurator-pipeline | quick-start

```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

