### PR TITLE
pipeline: complete pipeline logs cli

### DIFF
--- a/cmd/kurator/app/pipeline/execution/execution.go
+++ b/cmd/kurator/app/pipeline/execution/execution.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kurator.dev/kurator/cmd/kurator/app/pipeline/execution/list"
+	"kurator.dev/kurator/cmd/kurator/app/pipeline/execution/logs"
 	"kurator.dev/kurator/pkg/generic"
 )
 
@@ -34,6 +35,7 @@ func NewCmd(opts *generic.Options) *cobra.Command {
 	}
 
 	executionCmd.AddCommand(list.NewCmd(opts))
+	executionCmd.AddCommand(logs.NewCmd(opts))
 
 	return executionCmd
 }

--- a/cmd/kurator/app/pipeline/execution/logs/logs.go
+++ b/cmd/kurator/app/pipeline/execution/logs/logs.go
@@ -1,0 +1,74 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"kurator.dev/kurator/pkg/generic"
+	"kurator.dev/kurator/pkg/pipeline/execution/logs"
+)
+
+func NewCmd(opts *generic.Options) *cobra.Command {
+	var Args = logs.Args{}
+	logsCmd := &cobra.Command{
+		Use:     "logs",
+		Short:   "Display aggregated logs from multiple tasks within kurator pipeline execution",
+		Example: getExample(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return fmt.Errorf("please specify the pipeline execution name")
+			}
+
+			pipelineExecutionName := args[0] // the first one in args[] is the name of pipeline execution
+
+			PipelineList, err := logs.NewPipelineLogs(opts, &Args, pipelineExecutionName)
+			if err != nil {
+				logrus.Errorf("pipeline excution logs init error: %v", err)
+				return fmt.Errorf("pipeline excution logs init error: %v", err)
+			}
+
+			logrus.Debugf("start logs pipeline execution obj, Global: %+v ", opts)
+			if err := PipelineList.LogsExecute(); err != nil {
+				logrus.Errorf("pipeline logs execute error: %v", err)
+				return fmt.Errorf("pipeline logs execute error: %v", err)
+			}
+
+			return nil
+		},
+	}
+
+	logsCmd.PersistentFlags().StringVarP(&Args.Namespace, "namespace", "n", "default", "specific namespace")
+	logsCmd.PersistentFlags().Int64Var(&Args.TailLines, "tail", 0, "number of lines to display from the end of the logs; must be greater than 0 to take effect")
+
+	return logsCmd
+}
+
+func getExample() string {
+	return `  # Display aggregated logs from an example pipeline execution in the default namespace
+  kurator pipeline execution logs example-pipeline-execution
+
+  # Display aggregated logs from an example pipeline execution in a specific namespace (replace 'example-namespace' with your namespace)
+  kurator pipeline execution logs example-pipeline-execution -n example-namespace
+
+  # Display the last 10 lines of logs from an example pipeline execution
+  kurator pipeline execution logs example-pipeline-execution --tail 10
+`
+}

--- a/cmd/kurator/app/pipeline/execution/logs/logs.go
+++ b/cmd/kurator/app/pipeline/execution/logs/logs.go
@@ -56,7 +56,7 @@ func NewCmd(opts *generic.Options) *cobra.Command {
 	}
 
 	logsCmd.PersistentFlags().StringVarP(&Args.Namespace, "namespace", "n", "default", "specific namespace")
-	logsCmd.PersistentFlags().Int64Var(&Args.TailLines, "tail", 0, "number of lines to display from the end of the logs; must be greater than 0 to take effect")
+	logsCmd.PersistentFlags().Int64Var(&Args.TailLines, "tail", 0, "number of lines to display from the end of the logs in each task pod container, must be greater than 0 to take effect")
 
 	return logsCmd
 }

--- a/pkg/pipeline/execution/logs/logs.go
+++ b/pkg/pipeline/execution/logs/logs.go
@@ -42,7 +42,7 @@ type pipelineLogs struct {
 // Args holds the command line arguments for the logs command.
 type Args struct {
 	Namespace string // Namespace from which to fetch the logs.
-	TailLines int64  // Number of lines to display from the end of the logs, must be greater than 0 to take effect
+	TailLines int64  // Number of lines to display from the end of the logs in each task pod container, must be greater than 0 to take effect
 }
 
 // NewPipelineLogs creates a new pipelineLogs instance.
@@ -137,7 +137,7 @@ func (p *pipelineLogs) fetchAndPrintPodLogs(taskRunName, namespace string) error
 	return nil
 }
 
-// generatePodName gets the pod name for a taskrun. The taskRunName and the name of the pod executing the task differ only by "-pod"
+// getPodNameFromTaskRun gets the pod name for a taskrun. The taskRunName and the name of the pod executing the task differ only by "-pod"
 func getPodNameFromTaskRun(taskRunName string) string {
 	return taskRunName + "-pod"
 }

--- a/pkg/pipeline/execution/logs/logs.go
+++ b/pkg/pipeline/execution/logs/logs.go
@@ -1,0 +1,143 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/sirupsen/logrus"
+	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"kurator.dev/kurator/pkg/client"
+	"kurator.dev/kurator/pkg/generic"
+)
+
+// pipelineLogs is used to handle and display aggregated logs from a specific pipeline execution.
+type pipelineLogs struct {
+	*client.Client       // Embedded client for API interactions.
+	args           *Args // Arguments passed through command line flags.
+	options        *generic.Options
+	name           string // Name of the pipeline execution to fetch logs for.
+}
+
+// Args holds the command line arguments for the logs command.
+type Args struct {
+	Namespace string // Namespace from which to fetch the logs.
+	TailLines int64  // Number of lines to display from the end of the logs, must be greater than 0 to take effect
+}
+
+// NewPipelineLogs creates a new pipelineLogs instance.
+func NewPipelineLogs(opts *generic.Options, args *Args, pipelineExecutionName string) (*pipelineLogs, error) {
+	pList := &pipelineLogs{
+		options: opts,
+		args:    args,
+		name:    pipelineExecutionName,
+	}
+	rest := opts.RESTClientGetter()
+	c, err := client.NewClient(rest)
+	if err != nil {
+		return nil, err
+	}
+	pList.Client = c
+	return pList, nil
+}
+
+// LogsExecute fetches and displays aggregated logs from pipeline execution.
+func (p *pipelineLogs) LogsExecute() error {
+	namespace := p.args.Namespace
+
+	pipelineRun := &tektonapi.PipelineRun{}
+
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      p.name,
+	}
+
+	// Retrieve the PipelineRun object
+	if err := p.CtrlRuntimeClient().Get(context.Background(), namespacedName, pipelineRun); err != nil {
+		logrus.Errorf("failed to get PipelineRun '%s' in namespace '%s', %v", p.name, namespace, err)
+		return err
+	}
+
+	// Retrieve the ChildReferences of TaskRun
+	taskPodList := pipelineRun.Status.ChildReferences
+
+	// Iterate through each TaskRun to fetch their logs
+	for _, taskRef := range taskPodList {
+		if taskRef.Kind == "TaskRun" {
+			logrus.Infof("Fetching logs for TaskRun: %s", taskRef.Name)
+			if err := p.fetchAndPrintPodLogs(taskRef.Name, namespace); err != nil {
+				logrus.Errorf("failed to fetch logs for TaskRun '%s' in namespace '%s', %v", taskRef.Name, namespace, err)
+				// here just continue to attempt fetching logs for other TaskRuns, rather than directly return an error.
+			}
+		}
+	}
+
+	return nil
+}
+
+// fetchAndPrintPodLogs fetches and prints the logs of the pod associated with a given TaskRun.
+func (p *pipelineLogs) fetchAndPrintPodLogs(taskRunName, namespace string) error {
+	podName := getPodNameFromTaskRun(taskRunName)
+	pod := &corev1.Pod{}
+
+	// Get the details of the Pod
+	if err := p.Client.CtrlRuntimeClient().Get(context.Background(), ctrlclient.ObjectKey{Name: podName, Namespace: namespace}, pod); err != nil {
+		return err
+	}
+
+	// Iterate through each container in the Pod to fetch logs
+	for _, container := range pod.Spec.Containers {
+		logrus.Infof("Fetching logs for container '%s' in Pod '%s'", container.Name, podName)
+
+		podLogOpts := corev1.PodLogOptions{Container: container.Name}
+		if p.args.TailLines > 0 {
+			podLogOpts.TailLines = &p.args.TailLines
+		}
+
+		req := p.Client.KubeClient().CoreV1().Pods(namespace).GetLogs(podName, &podLogOpts)
+
+		podLogs, err := req.Stream(context.Background())
+		if err != nil {
+			logrus.Errorf("Failed to fetch logs for container '%s', %v", container.Name, err)
+			continue
+		}
+
+		// Read and display the logs
+		buf := new(bytes.Buffer)
+		_, err = io.Copy(buf, podLogs)
+		podLogs.Close()
+		if err != nil {
+			logrus.Errorf("Failed to read logs for container '%s', %v", container.Name, err)
+			continue
+		}
+
+		logrus.Infof("Logs from container '%s':\n%s", container.Name, buf.String())
+	}
+
+	return nil
+}
+
+// generatePodName gets the pod name for a taskrun. The taskRunName and the name of the pod executing the task differ only by "-pod"
+func getPodNameFromTaskRun(taskRunName string) string {
+	return taskRunName + "-pod"
+}


### PR DESCRIPTION
**What type of PR is this?**


/kind feature


**What this PR does / why we need it**:
part of https://github.com/kurator-dev/kurator/pull/533

here shows how to use it

```
root@xql:~/go/src/kurator.dev/kurator#kurator pipeline execution logs -h
Display aggregated logs from multiple tasks within kurator pipeline execution

Usage:
  kurator pipeline execution logs [flags]

Examples:
  # Display aggregated logs from an example pipeline execution in the default namespace
  kurator pipeline execution logs example-pipeline-execution

  # Display aggregated logs from an example pipeline execution in a specific namespace (replace 'example-namespace' with your namespace)
  kurator pipeline execution logs example-pipeline-execution -n example-namespace

  # Display the last 10 lines of logs from an example pipeline execution
  kurator pipeline execution logs example-pipeline-execution --tail 10


Flags:
  -h, --help               help for logs
  -n, --namespace string   specific namespace (default "default")
      --tail int           number of lines to display from the end of the logs; must be greater than 0 to take effect

Global Flags:
      --context string           name of the kubeconfig context to use
      --dry-run                  console/log output only, make no changes.
      --home-dir string          install path, default to $HOME/.kurator (default "/root/.kurator")
  -c, --kubeconfig string        path to the kubeconfig file, default to karmada apiserver config (default "/etc/karmada/karmada-apiserver.config")
      --wait-interval duration   interval used for checking pod ready, default value is 1s. (default 1s)
      --wait-timeout duration    timeout used for checking pod ready, default value is 2m. (default 2m0s)


root@xql:~/go/src/kurator.dev/kurator# kurator pipeline execution logs quick-start-run-frb7l  -n kurator-pipeline --tail 10 --kubeconfig /root/.kube/kurator-host.config
INFO[2024-01-04 11:47:34] Fetching logs for TaskRun: quick-start-run-frb7l-git-clone 
INFO[2024-01-04 11:47:34] Fetching logs for container 'step-clone' in Pod 'quick-start-run-frb7l-git-clone-pod' 
INFO[2024-01-04 11:47:34] Logs from container 'step-clone':
+ cd /workspace/source/
+ git rev-parse HEAD
+ RESULT_SHA=1858f8e5129516d6e7d9ad993b1ec41cef922d18
+ EXIT_CODE=0
+ '[' 0 '!=' 0 ]
+ git log -1 '--pretty=%ct'
+ RESULT_COMMITTER_DATE=1703581193
+ printf '%s' 1703581193
+ printf '%s' 1858f8e5129516d6e7d9ad993b1ec41cef922d18
+ printf '%s' https://github.com/Xieql/podinfo 
INFO[2024-01-04 11:47:34] Fetching logs for TaskRun: quick-start-run-frb7l-build-and-push-image 
INFO[2024-01-04 11:47:34] Fetching logs for container 'step-build-and-push' in Pod 'quick-start-run-frb7l-build-and-push-image-pod' 
INFO[2024-01-04 11:47:34] Logs from container 'step-build-and-push':
INFO[0161] RUN chown -R app:app ./                      
INFO[0161] Cmd: /bin/sh                                 
INFO[0161] Args: [-c chown -R app:app ./]               
INFO[0161] Running: [/bin/sh -c chown -R app:app ./]    
INFO[0161] Taking snapshot of full filesystem...        
INFO[0162] USER app                                     
INFO[0162] Cmd: USER                                    
INFO[0162] CMD ["./podinfo"]                            
INFO[0162] Pushing image to ghcr.io/xieql/kurator-final:0.4.1 
INFO[0188] Pushed ghcr.io/xieql/kurator-final@sha256:73c1ad5046233adb70aae2ee5df6e00f2c521e89cc980a954dc024d12add8daf  
INFO[2024-01-04 11:47:34] Fetching logs for container 'step-write-url' in Pod 'quick-start-run-frb7l-build-and-push-image-pod' 
INFO[2024-01-04 11:47:34] Logs from container 'step-write-url':
ghcr.io/xieql/kurator-final:0.4.1 
INFO[2024-01-04 11:47:34] Fetching logs for TaskRun: quick-start-run-frb7l-cat-readme 
INFO[2024-01-04 11:47:34] Fetching logs for container 'step-cat-readme-quick-start' in Pod 'quick-start-run-frb7l-cat-readme-pod' 
INFO[2024-01-04 11:47:34] Logs from container 'step-cat-readme-quick-start':
To delete podinfo's Helm repository and release from your cluster run:

flux -n default delete source helm podinfo
flux -n default delete helmrelease podinfo

If you wish to manage the lifecycle of your applications in a **GitOps** manner, check out
this [workflow example](https://github.com/fluxcd/flux2-kustomize-helm-example)
for multi-env deployments with Flux, Kustomize and Helm. 
INFO[2024-01-04 11:47:34] Fetching logs for TaskRun: quick-start-run-frb7l-go-test 
INFO[2024-01-04 11:47:34] Fetching logs for container 'step-unit-test' in Pod 'quick-start-run-frb7l-go-test-pod' 
INFO[2024-01-04 11:47:34] Logs from container 'step-unit-test':
--- PASS: TestInfoHandler (0.00s)
=== RUN   TestStatusHandler
--- PASS: TestStatusHandler (0.00s)
=== RUN   TestTokenHandler
--- PASS: TestTokenHandler (0.00s)
=== RUN   TestVersionHandler
--- PASS: TestVersionHandler (0.00s)
PASS
coverage: 14.4% of statements
ok  	github.com/stefanprodan/podinfo/pkg/api	1.088s	coverage: 14.4% of statements 
INFO[2024-01-04 11:47:34] Fetching logs for TaskRun: quick-start-run-frb7l-go-lint 
INFO[2024-01-04 11:47:34] Fetching logs for container 'step-lint' in Pod 'quick-start-run-frb7l-go-lint-pod' 
INFO[2024-01-04 11:47:34] Logs from container 'step-lint':
level=info msg="[config_reader] Config search paths: [./ /workspace/src /workspace / /root]"
level=info msg="[lintersdb] Active 2 linters: [govet ineffassign]"
level=info msg="[loader] Go packages loading at mode 575 (deps|imports|types_sizes|compiled_files|files|name|exports_file) took 1m0.435700461s"
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 4.381259ms"
level=info msg="[linters_context/goanalysis] analyzers took 1.651993451s with top 10 stages: inspect: 842.409271ms, ctrlflow: 402.369985ms, printf: 382.21663ms, ineffassign: 12.079525ms, slog: 3.20068ms, lostcancel: 1.346293ms, copylocks: 1.333706ms, directive: 1.287065ms, bools: 976.125µs, composites: 435.523µs"
level=info msg="[runner] processing took 2.828µs with stages: max_same_issues: 349ns, skip_dirs: 325ns, nolint: 302ns, cgo: 230ns, exclude-rules: 208ns, max_from_linter: 146ns, source_code: 143ns, path_prettifier: 133ns, filename_unadjuster: 133ns, autogenerated_exclude: 131ns, skip_files: 124ns, identifier_marker: 118ns, max_per_file_from_linter: 72ns, severity-rules: 59ns, path_shortener: 56ns, sort_results: 53ns, diff: 51ns, exclude: 50ns, uniq_by_line: 50ns, fixer: 50ns, path_prefixer: 45ns"
level=info msg="[runner] linters took 3.81614172s with stages: goanalysis_metalinter: 3.816076131s"
level=info msg="File cache stats: 0 entries of total size 0B"
level=info msg="Memory: 644 samples, avg is 35.5MB, max is 435.9MB"
level=info msg="Execution took 1m4.265454941s" 
```
