### PR TITLE
doc: add pipeline api reference 

### DIFF
--- a/docs/content/en/docs/references/app-api.md
+++ b/docs/content/en/docs/references/app-api.md
@@ -2,7 +2,7 @@
 title: "Application API reference"
 linkTitle: "Application API"
 weight: 40
-description: "Detailed docuementation on the Application API"
+description: "Detailed documentation on the Application API"
 ---
 
 {{< reference apps_v1alpha1_types >}}

--- a/docs/content/en/docs/references/backup-api.md
+++ b/docs/content/en/docs/references/backup-api.md
@@ -2,7 +2,7 @@
 title: "Backup API reference"
 linkTitle: "Backup API"
 weight: 50
-description: "Detailed docuementation on the Backup API"
+description: "Detailed documentation on the Backup API"
 ---
 
 {{< reference backups_v1alpha1_types >}}

--- a/docs/content/en/docs/references/cluster-api.md
+++ b/docs/content/en/docs/references/cluster-api.md
@@ -2,7 +2,7 @@
 title: "Cluster API reference"
 linkTitle: "Cluster API"
 weight: 10
-description: "Detailed docuementation on the clusters API"
+description: "Detailed documentation on the clusters API"
 ---
 
 {{< reference cluster_v1alpha1_types >}}

--- a/docs/content/en/docs/references/fleet-api.md
+++ b/docs/content/en/docs/references/fleet-api.md
@@ -2,7 +2,7 @@
 title: "Fleet API reference"
 linkTitle: "Fleet API"
 weight: 30
-description: "Detailed docuementation on the fleet API"
+description: "Detailed documentation on the fleet API"
 ---
 
 {{< reference fleet_v1alpha1_types >}}

--- a/docs/content/en/docs/references/infra-api.md
+++ b/docs/content/en/docs/references/infra-api.md
@@ -2,7 +2,7 @@
 title: "Infra API reference"
 linkTitle: "Infra API"
 weight: 20
-description: "Detailed docuementation on the infras API"
+description: "Detailed documentation on the infras API"
 ---
 
 {{< reference infra_v1alpha1_types >}}

--- a/docs/content/en/docs/references/pipeline-api.md
+++ b/docs/content/en/docs/references/pipeline-api.md
@@ -1,0 +1,9 @@
+---
+title: "Pipeline API reference"
+linkTitle: "Pipeline API"
+weight: 60
+description: "Detailed documentation on the Pipeline API"
+---
+
+{{< reference pipeline_v1alpha1_types >}}
+


### PR DESCRIPTION
**What type of PR is this?**


/kind documentation

**What this PR does / why we need it**:
add pipeline api reference in Kurator website
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

It's worthy to note that since `TaskTemplate` is a string type, it will be converted into a string when auto-generating API documentation. 

Therefore, descriptions like these `GitClone TaskTemplate = 'git-clone'` will not be included in the API reference documents.

I will list them again in the user documentation that will be created later.

