### PR TITLE
change the RolloutTimeoutSeconds to be of type *int32

### DIFF
--- a/docs/content/en/references/apps_v1alpha1_types.html
+++ b/docs/content/en/references/apps_v1alpha1_types.html
@@ -1830,7 +1830,7 @@ TrafficAnalysis
 <td>
 <code>rolloutTimeoutSeconds</code><br>
 <em>
-int
+int32
 </em>
 </td>
 <td>

--- a/manifests/charts/fleet-manager/crds/apps.kurator.dev_applications.yaml
+++ b/manifests/charts/fleet-manager/crds/apps.kurator.dev_applications.yaml
@@ -1213,6 +1213,7 @@ spec:
                                 time in seconds for a preview deployment to make progress
                                 before it is considered to be failed. Defaults to
                                 600.
+                              format: int32
                               type: integer
                             skipTrafficAnalysis:
                               description: SkipTrafficAnalysis promotes the preview

--- a/pkg/apis/apps/v1alpha1/types.go
+++ b/pkg/apis/apps/v1alpha1/types.go
@@ -156,7 +156,7 @@ type RolloutPolicy struct {
 	// preview deployment to make progress before it is considered to be failed.
 	// Defaults to 600.
 	// +optional
-	RolloutTimeoutSeconds *int `json:"rolloutTimeoutSeconds,omitempty"`
+	RolloutTimeoutSeconds *int32 `json:"rolloutTimeoutSeconds,omitempty"`
 
 	// SkipTrafficAnalysis promotes the preview release without analyzing it.
 	// +optional

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -738,7 +738,7 @@ func (in *RolloutPolicy) DeepCopyInto(out *RolloutPolicy) {
 	}
 	if in.RolloutTimeoutSeconds != nil {
 		in, out := &in.RolloutTimeoutSeconds, &out.RolloutTimeoutSeconds
-		*out = new(int)
+		*out = new(int32)
 		**out = **in
 	}
 	return


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
change the RolloutTimeoutSeconds in the rollour api to be of type *int32. 
Reduce pointer type conversions and avoid empty pointer panic.
