### PR TITLE
pipeline: fix render rbac for chain secret

### DIFF
--- a/pkg/fleet-manager/pipeline/render/rbac.go
+++ b/pkg/fleet-manager/pipeline/render/rbac.go
@@ -29,9 +29,10 @@ const (
 // RBACConfig contains the configuration data required for the RBAC template.
 // Both PipelineName and PipelineNamespace are required.
 type RBACConfig struct {
-	PipelineName      string // Name of the pipeline.
-	PipelineNamespace string // Kubernetes namespace where the pipeline is deployed.
-	OwnerReference    *metav1.OwnerReference
+	PipelineName         string // Name of the pipeline.
+	PipelineNamespace    string // Kubernetes namespace where the pipeline is deployed.
+	OwnerReference       *metav1.OwnerReference
+	ChainCredentialsName string
 }
 
 // ServiceAccountName generates the service account name using the pipeline name.
@@ -59,9 +60,11 @@ metadata:
     name: "{{ .OwnerReference.Name }}"
     uid: "{{ .OwnerReference.UID }}"
 {{- end }}
+{{- if .ChainCredentialsName }}
 secrets:
   - name: "chain-credentials"
     namespace: "{{ .PipelineNamespace }}"
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pkg/fleet-manager/pipeline/render/rbac_test.go
+++ b/pkg/fleet-manager/pipeline/render/rbac_test.go
@@ -69,6 +69,7 @@ func TestRenderRBAC(t *testing.T) {
 					Name:       "example-deployment",
 					UID:        "12345678-1234-1234-1234-123456789abc",
 				},
+				ChainCredentialsName: "chain-credentials",
 			},
 			expectError:  false,
 			expectedFile: "with-owner.yaml",

--- a/pkg/fleet-manager/pipeline/render/testdata/rbac/default-example.yaml
+++ b/pkg/fleet-manager/pipeline/render/testdata/rbac/default-example.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   name: "example"
   namespace: "default"
-secrets:
-  - name: "chain-credentials"
-    namespace: "default"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
**What type of PR is this?**



/kind bug

**What this PR does / why we need it**:

The `chain-credentials` in service account should be a optional filed,

we  need it only when we have push image task.
