### PR TITLE
Automate --kubeconfig in kurator CLI to default to kurator-host.config

### DIFF
--- a/pkg/generic/options.go
+++ b/pkg/generic/options.go
@@ -68,7 +68,7 @@ func (g *Options) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&g.HomeDir, "home-dir", path.Join(homeDir, ".kurator"), "install path, default to $HOME/.kurator")
 
-	fs.StringVarP(&g.KubeConfig, "kubeconfig", "c", "/etc/karmada/karmada-apiserver.config", "path to the kubeconfig file, default to karmada apiserver config")
+	fs.StringVarP(&g.KubeConfig, "kubeconfig", "c", "/root/.kube/kurator-host.config", "path to the kubeconfig file, default to Kurator-host apiservice ")
 	fs.StringVar(&g.KubeContext, "context", "", "name of the kubeconfig context to use")
 
 	fs.BoolVar(&g.DryRun, "dry-run", false, "console/log output only, make no changes.")


### PR DESCRIPTION
**What this PR does / why we need it**:
Automate --kubeconfig in kurator CLI to default to kurator-host.config
**Which issue(s) this PR fixes**:
Fixes #542 

