### PR TITLE
sign kurator images

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build-push:
+    permissions:
+      id-token: write # To be able to get OIDC ID token to sign images.
     runs-on: ubuntu-latest
     steps:
       - name: Get image version
@@ -21,11 +23,23 @@ jobs:
         with:
           go-version: 1.20.x
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.0.3
+        with:
+          cosign-release: 'v1.13.1'
+        
       - name: Compile
         run: make build
 
       - name: Build Docker Image
         run: VERSION=${{ env.image_version }} make docker
+
+      - name: Sign Image
+        env:
+          VERSION: ${{ env.image_version }}
+          COSIGN_EXPERIMENTAL: 1
+          SIGN_IMAGE: 1
+        run: make sign-image
 
       - name: Login to ghcr.io
         # This is where you will update the PAT to GITHUB_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ docker-push: docker
 	docker push ${IMAGE_HUB}/cluster-operator:${IMAGE_TAG}
 	docker push ${IMAGE_HUB}/fleet-manager:${IMAGE_TAG}
 
+.PHONY: sign-image 
+sign-image:
+	./hack/image-sign.sh
+
 .PHONY: lint
 lint: golangci-lint lint-copyright lint-markdown lint-shellcheck
 

--- a/hack/image-sign.sh
+++ b/hack/image-sign.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+IMAGE_HUB=${IMAGE_HUB:-"ghcr.io/kurator-dev"}
+IMAGE_TAG=${VERSION:-"$(VERSION)"}
+SIGN_IMAGE=${SIGN_IMAGE:-"0"}
+
+CLUSTER_OPERATOR_IMAGE=${CLUSTER_OPERATOR_IMAGE:-"${IMAGE_HUB}/cluster-operator:${IMAGE_TAG}"}
+FLEET_MANAGER_IMAGE=${FLEET_MANAGER_IMAGE:-"${IMAGE_HUB}/fleet-manager:${IMAGE_TAG}"}
+
+if [ $SIGN_IMAGE = "1" ]; then
+    echo "Sign image: "${CLUSTER_OPERATOR_IMAGE}
+    cosign sign --yes ${CLUSTER_OPERATOR_IMAGE}
+    echo "Sign image: "${FLEET_MANAGER_IMAGE}
+    cosign sign --yes ${FLEET_MANAGER_IMAGE}
+else
+    echo "Warning: The build image is not signed"
+fi
+    

--- a/hack/image-sign.sh
+++ b/hack/image-sign.sh
@@ -7,11 +7,11 @@ SIGN_IMAGE=${SIGN_IMAGE:-"0"}
 CLUSTER_OPERATOR_IMAGE=${CLUSTER_OPERATOR_IMAGE:-"${IMAGE_HUB}/cluster-operator:${IMAGE_TAG}"}
 FLEET_MANAGER_IMAGE=${FLEET_MANAGER_IMAGE:-"${IMAGE_HUB}/fleet-manager:${IMAGE_TAG}"}
 
-if [ $SIGN_IMAGE = "1" ]; then
-    echo "Sign image: "${CLUSTER_OPERATOR_IMAGE}
-    cosign sign --yes ${CLUSTER_OPERATOR_IMAGE}
-    echo "Sign image: "${FLEET_MANAGER_IMAGE}
-    cosign sign --yes ${FLEET_MANAGER_IMAGE}
+if [ "$SIGN_IMAGE" = "1" ]; then
+    echo "Sign image: ""${CLUSTER_OPERATOR_IMAGE}"
+    cosign sign --yes "${CLUSTER_OPERATOR_IMAGE}"
+    echo "Sign image: ""${FLEET_MANAGER_IMAGE}"
+    cosign sign --yes "${FLEET_MANAGER_IMAGE}"
 else
     echo "Warning: The build image is not signed"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Now more and more cloud native projects like Kubenetes, has adopted [Sigstore](https://www.sigstore.dev/) for signing and verifying artifacts. Kurator images also need to signed with [cosign](https://github.com/sigstore/cosign)
**Which issue(s) this PR fixes**:
#587 

