### PR TITLE
Added a function to determine if the attachedcluster was created in the cluster

### DIFF
--- a/e2e/attachedcluster_test.go
+++ b/e2e/attachedcluster_test.go
@@ -93,8 +93,10 @@ var _ = ginkgo.Describe("[AttachedClusters] AttachedClusters testing", func() {
 		// step 2.create attachedclusters
 		attachedCreateErr := resources.CreateAttachedCluster(kuratorClient, attachedcluster)
 		gomega.Expect(attachedCreateErr).ShouldNot(gomega.HaveOccurred())
+		resources.WaitAttachedClusterFitWith(kuratorClient, namespace, memberClusterName, func(attachedCluster *clusterv1a1.AttachedCluster) bool {
+			return attachedCluster.Status.Ready
+		})
 
-		time.Sleep(3 * time.Second)
 		// step 3.create fleet
 		clusters := []*corev1.ObjectReference{
 			{

--- a/e2e/resources/attachedcluster.go
+++ b/e2e/resources/attachedcluster.go
@@ -77,7 +77,7 @@ func RemoveAttachedCluster(client kurator.Interface, namespace, name string) err
 	return nil
 }
 
-// WaitAttachedClusterFitWith wait AttachedCluster sync with fit func.
+// WaitAttachedClusterFitWith wait attachedCluster sync with fit func.
 func WaitAttachedClusterFitWith(client kurator.Interface, namespace, name string, fit func(attachedCluster *clusterv1a1.AttachedCluster) bool) {
 	gomega.Eventually(func() bool {
 		attachedClusterPresentOnCluster, err := client.ClusterV1alpha1().AttachedClusters(namespace).Get(context.TODO(), name, metav1.GetOptions{})
@@ -85,5 +85,5 @@ func WaitAttachedClusterFitWith(client kurator.Interface, namespace, name string
 			return false
 		}
 		return fit(attachedClusterPresentOnCluster)
-	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+	}, pollTimeout, pollIntervalInHostCluster).Should(gomega.Equal(true))
 }

--- a/e2e/resources/attachedcluster.go
+++ b/e2e/resources/attachedcluster.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"context"
 
+	"github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -74,4 +75,15 @@ func RemoveAttachedCluster(client kurator.Interface, namespace, name string) err
 		}
 	}
 	return nil
+}
+
+// WaitAttachedClusterFitWith wait AttachedCluster sync with fit func.
+func WaitAttachedClusterFitWith(client kurator.Interface, namespace, name string, fit func(attachedCluster *clusterv1a1.AttachedCluster) bool) {
+	gomega.Eventually(func() bool {
+		attachedClusterPresentOnCluster, err := client.ClusterV1alpha1().AttachedClusters(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return fit(attachedClusterPresentOnCluster)
+	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 }

--- a/e2e/resources/constant.go
+++ b/e2e/resources/constant.go
@@ -1,0 +1,26 @@
+/*
+Copyright Kurator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import "time"
+
+const (
+	// pollInterval defines the interval time for a poll operation.
+	pollInterval = 5 * time.Second
+	// pollTimeout defines the time after which the poll operation times out.
+	pollTimeout = 420 * time.Second
+)

--- a/e2e/resources/constant.go
+++ b/e2e/resources/constant.go
@@ -19,8 +19,8 @@ package resources
 import "time"
 
 const (
-	// pollInterval defines the interval time for a poll operation.
-	pollInterval = 5 * time.Second
+	// pollIntervalInHostCluster defines the interval time for a poll operation.
+	pollIntervalInHostCluster = 3 * time.Second
 	// pollTimeout defines the time after which the poll operation times out.
 	pollTimeout = 420 * time.Second
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a function to determine if the attachedcluster was created in the cluster. Replaces the unstable checking of clusters at fixed intervals.
**Which issue(s) this PR fixes**:
a part of #436 

