### PR TITLE
Pinning the Version of license-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ mod-download-go:
 
 .PHONY: mirror-licenses
 mirror-licenses: mod-download-go; \
-	go install istio.io/tools/cmd/license-lint@latest; \
+	go install istio.io/tools/cmd/license-lint@v0.0.0-20240221165422-57f6bfb4cd73;  \
 	rm -fr licenses; \
 	license-lint --mirror
 

--- a/hack/e2e-test/install-kurator.sh
+++ b/hack/e2e-test/install-kurator.sh
@@ -12,7 +12,7 @@ export KUBECONFIG=${MAIN_KUBECONFIG}
 COMMIT_ID=$(git rev-parse --short HEAD)
 VERSION=$(echo "$COMMIT_ID" | grep -o '^[0-9]')
 
-sleep 5s
+sleep 10s 
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The licenses check functionality in the CI system was broken due to an issue where the version of license-lint was upgraded automatically.
By locking down license-lint to a specific, known-good version, the licenses check task is able to perform reliably on each build
**Which issue(s) this PR fixes**:
Fixes #608 


