### PR TITLE
Automatically create the directory if it does not exist

### DIFF
--- a/cmd/crd-gen-tool/main.go
+++ b/cmd/crd-gen-tool/main.go
@@ -71,6 +71,10 @@ func main() {
 	clusterApiVersion := env("CLUSTER_API_PROVIDER_VERSION", "v1.2.5")
 	awsProviderVersion := env("AWS_PROVIDER_VERSION", "v2.0.0")
 
+	if err := os.MkdirAll(crdOutputDir, 0755); err != nil {
+		log.Fatalf("MkdirAll %s got error %+v", crdOutputDir, err)
+	}
+
 	genCapiCore(crdOutputDir, clusterApiVersion)
 	genCapiBootstrap(crdOutputDir, clusterApiVersion)
 	genCapiControlplane(crdOutputDir, clusterApiVersion)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Automatically create the directory if it does not exist, assuming that no subdirectories will exist.
```
$ go run cmd/crd-gen-tool/main.go
start to gen Cluster API core crds, version: v1.2.5 output: manifests/charts/base/templates
write file err: open manifests/charts/base/templates/clusterclasses.cluster.x-k8s.io.yaml: no such file or directoryexit status 255
```

**Does this PR introduce a user-facing change?**
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

