### PR TITLE
doc: fs.inotify hint for karmada deploy

### DIFF
--- a/docs/content/en/docs/Integrations/karmada.md
+++ b/docs/content/en/docs/Integrations/karmada.md
@@ -41,7 +41,7 @@ kurator install karmada --kubeconfig=/root/.kube/config
 karmada installation parameters can be set with `--set`, e.g.
 
 ```bash
-kurator install karmada --set karmada-data=/etc/Karmada-test --set port=32222 --kubeconfig /root/.kube/config
+kurator install karmada --set karmada-data=/etc/Karmada-test --set port=32222 --kubeconfig ~/.kube/config
 ```
 
 ### Add kubernetes cluster to karmada control plane

--- a/docs/content/en/docs/Integrations/karmada.md
+++ b/docs/content/en/docs/Integrations/karmada.md
@@ -18,6 +18,8 @@ cd kurator
 hack/local-dev-setup.sh
 ```
 
+> `fs.inotify.max_user_watches` and `fs.inotify.max_user_instances` may need to be adjusted as described [here](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files)
+
 ### Deploy Karmada
 
 Compile `kurator` from source
@@ -39,7 +41,7 @@ kurator install karmada --kubeconfig=/root/.kube/config
 karmada installation parameters can be set with `--set`, e.g.
 
 ```bash
-kurator install karmada --set karmada-data=/etc/Karmada-test --set port=32222 --kubeconfig .kube/config
+kurator install karmada --set karmada-data=/etc/Karmada-test --set port=32222 --kubeconfig /root/.kube/config
 ```
 
 ### Add kubernetes cluster to karmada control plane
@@ -56,7 +58,7 @@ kurator join karmada member2 \
     --cluster-context=kurator-member2
 ```
 
-Show members of karmada 
+Show members of karmada
 
 ```bash
 kubectl --kubeconfig /etc/karmada/karmada-apiserver.config get clusters

--- a/docs/content/en/docs/fleet-manager/manage-attachedcluster.md
+++ b/docs/content/en/docs/fleet-manager/manage-attachedcluster.md
@@ -30,7 +30,7 @@ kubectl create secret generic kurator-member1 --from-file=kurator-member1.config
 kubectl create secret generic kurator-member2 --from-file=kurator-member2.config=/root/.kube/kurator-member2.config
 ```
 
-Please note, here we have named the secrets as `kurator-member1` and `kurator-member2` respectively, and set the key to save the kubeconfig in the secret as `kurator-member1.config` and `kurator-member1.config` respectively.
+Please note, here we have named the secrets as `kurator-member1` and `kurator-member2` respectively, and set the key to save the kubeconfig in the secret as `kurator-member1.config` and `kurator-member2.config` respectively.
 You can modify these two elements according to your needs.
 
 ## Create attachedCluster resources


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind documentation

-->

**What this PR does / why we need it**:

`fs.inotify` problem may be encountered  as described in [Pod errors due to “too many open files”](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files) of pod karmada webhook. Also some typo fixs.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

