### PR TITLE
Fix: Update Makefile for Unlink error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ gen-crd: init-codegen ## Generate WebhookConfiguration, ClusterRole and CustomRe
 	hack/update-crdgen.sh
 
 
-PACKAGE					    := kurator.dev
+PACKAGE					    := kurator.dev/kurator
 GOPATH_SHIM                 := ${PWD}/.gopath
 PACKAGE_SHIM                := $(GOPATH_SHIM)/src/$(PACKAGE)
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind bug

**What this PR does / why we need it**:

`PACKAGE_SHIM` in `Makefile` is a directory and `.INTERMEDIATE` rm cannot handle it.

> ref: [kyverno/Makefile](https://github.com/kyverno/kyverno/blob/main/Makefile)

**Which issue(s) this PR fixes**:
Fixes #661

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

