### PR TITLE
Feat: Single cluster deployment application

### DIFF
--- a/docs/content/en/references/apps_v1alpha1_types.html
+++ b/docs/content/en/references/apps_v1alpha1_types.html
@@ -103,7 +103,8 @@ ApplicationDestination
 <td>
 <em>(Optional)</em>
 <p>Destination defines the destination clusters where the artifacts will be synced.
-It can be overridden by the syncPolicies&rsquo; destination.</p>
+It can be overridden by the syncPolicies&rsquo; destination.
+And if both the current field and syncPolicies&rsquo; destination are empty, the application will be deployed directly in the current cluster.</p>
 </td>
 </tr>
 </table>
@@ -346,7 +347,8 @@ ApplicationDestination
 <td>
 <em>(Optional)</em>
 <p>Destination defines the destination clusters where the artifacts will be synced.
-It can be overridden by the syncPolicies&rsquo; destination.</p>
+It can be overridden by the syncPolicies&rsquo; destination.
+And if both the current field and syncPolicies&rsquo; destination are empty, the application will be deployed directly in the current cluster.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/content/en/references/apps_v1alpha1_types.html
+++ b/docs/content/en/references/apps_v1alpha1_types.html
@@ -104,7 +104,7 @@ ApplicationDestination
 <em>(Optional)</em>
 <p>Destination defines the destination clusters where the artifacts will be synced.
 It can be overridden by the syncPolicies&rsquo; destination.
-And if both the current field and syncPolicies&rsquo; destination are empty, the application will be deployed directly in the current cluster.</p>
+And if both the current field and syncPolicies&rsquo; destination are empty, the application will be deployed directly in the cluster where kurator resides.</p>
 </td>
 </tr>
 </table>
@@ -348,7 +348,7 @@ ApplicationDestination
 <em>(Optional)</em>
 <p>Destination defines the destination clusters where the artifacts will be synced.
 It can be overridden by the syncPolicies&rsquo; destination.
-And if both the current field and syncPolicies&rsquo; destination are empty, the application will be deployed directly in the current cluster.</p>
+And if both the current field and syncPolicies&rsquo; destination are empty, the application will be deployed directly in the cluster where kurator resides.</p>
 </td>
 </tr>
 </tbody>

--- a/examples/application/gitrepo-kustomization-demo-without-fleet.yaml
+++ b/examples/application/gitrepo-kustomization-demo-without-fleet.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps.kurator.dev/v1alpha1
+kind: Application
+metadata:
+  name: rollout-demo
+  namespace: default
+spec:
+  source:
+    gitRepository:
+      interval: 3m0s
+      ref:
+        branch: master
+      timeout: 1m0s
+      url: https://github.com/stefanprodan/podinfo
+  syncPolicies:
+    - kustomization:
+        interval: 0s
+        path: ./deploy/webapp
+        prune: true
+        timeout: 2m0s
+    - kustomization:
+        targetNamespace: default
+        interval: 5m0s
+        path: ./kustomize
+        prune: true
+        timeout: 2m0s

--- a/manifests/charts/fleet-manager/crds/apps.kurator.dev_applications.yaml
+++ b/manifests/charts/fleet-manager/crds/apps.kurator.dev_applications.yaml
@@ -46,6 +46,7 @@ spec:
                 description: |-
                   Destination defines the destination clusters where the artifacts will be synced.
                   It can be overridden by the syncPolicies' destination.
+                  And if both the current field and syncPolicies' destination are empty, the application will be deployed directly in the current cluster.
                 properties:
                   clusterSelector:
                     description: |-

--- a/manifests/charts/fleet-manager/crds/apps.kurator.dev_applications.yaml
+++ b/manifests/charts/fleet-manager/crds/apps.kurator.dev_applications.yaml
@@ -46,7 +46,7 @@ spec:
                 description: |-
                   Destination defines the destination clusters where the artifacts will be synced.
                   It can be overridden by the syncPolicies' destination.
-                  And if both the current field and syncPolicies' destination are empty, the application will be deployed directly in the current cluster.
+                  And if both the current field and syncPolicies' destination are empty, the application will be deployed directly in the cluster where kurator resides.
                 properties:
                   clusterSelector:
                     description: |-

--- a/pkg/apis/apps/v1alpha1/types.go
+++ b/pkg/apis/apps/v1alpha1/types.go
@@ -47,6 +47,7 @@ type ApplicationSpec struct {
 	SyncPolicies []*ApplicationSyncPolicy `json:"syncPolicies"`
 	// Destination defines the destination clusters where the artifacts will be synced.
 	// It can be overridden by the syncPolicies' destination.
+	// And if both the current field and syncPolicies' destination are empty, the application will be deployed directly in the current cluster.
 	// +optional
 	Destination *ApplicationDestination `json:"destination,omitempty"`
 }

--- a/pkg/apis/apps/v1alpha1/types.go
+++ b/pkg/apis/apps/v1alpha1/types.go
@@ -47,7 +47,7 @@ type ApplicationSpec struct {
 	SyncPolicies []*ApplicationSyncPolicy `json:"syncPolicies"`
 	// Destination defines the destination clusters where the artifacts will be synced.
 	// It can be overridden by the syncPolicies' destination.
-	// And if both the current field and syncPolicies' destination are empty, the application will be deployed directly in the current cluster.
+	// And if both the current field and syncPolicies' destination are empty, the application will be deployed directly in the cluster where kurator resides.
 	// +optional
 	Destination *ApplicationDestination `json:"destination,omitempty"`
 }

--- a/pkg/fleet-manager/fleet_cluster.go
+++ b/pkg/fleet-manager/fleet_cluster.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	clusterv1alpha1 "kurator.dev/kurator/pkg/apis/cluster/v1alpha1"
 	fleetapi "kurator.dev/kurator/pkg/apis/fleet/v1alpha1"
@@ -109,6 +110,13 @@ func ClientForCluster(client client.Client, ns string, cluster ClusterInterface)
 		return nil, err
 	}
 
+	return kclient.NewClient(kclient.NewRESTClientGetter(rest))
+}
+func WrapClient(client client.Client) (*kclient.Client, error) {
+	rest, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
 	return kclient.NewClient(kclient.NewRESTClientGetter(rest))
 }
 

--- a/pkg/webhooks/application_webhook.go
+++ b/pkg/webhooks/application_webhook.go
@@ -90,12 +90,13 @@ func validateFleet(in *v1alpha1.Application) field.ErrorList {
 		var (
 			firstPolicyFleet string
 			isFirst          = true
+			isNil            = false
 		)
 		for i, policy := range in.Spec.SyncPolicies {
 			// if individual policy fleet is not set, return err
 			if policy.Destination == nil || policy.Destination.Fleet == "" {
-				allErrs = append(allErrs, field.Required(field.NewPath("spec", "syncPolicies").Index(i).Child("destination", "fleet"), "must be set when application.spec.destination.fleet is not set"))
-				return allErrs
+				isNil = true
+				continue
 			}
 			if isFirst {
 				firstPolicyFleet = policy.Destination.Fleet
@@ -104,6 +105,9 @@ func validateFleet(in *v1alpha1.Application) field.ErrorList {
 			if !isFirst && firstPolicyFleet != policy.Destination.Fleet {
 				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "syncPolicies").Index(i).Child("destination", "fleet"), policy.Destination.Fleet, fmt.Sprintf("must be same as firstPolicyFleet:%v, because fleet must be consistent throughout the application", firstPolicyFleet)))
 			}
+		}
+		if isNil && !isFirst {
+			allErrs = append(allErrs, field.Required(field.NewPath("spec", "syncPolicies").Child("destination", "fleet"), "must be set when application.spec.destination.fleet is not set"))
 		}
 	}
 

--- a/pkg/webhooks/application_webhook_test.go
+++ b/pkg/webhooks/application_webhook_test.go
@@ -33,17 +33,7 @@ import (
 func TestValidApplicationValidation(t *testing.T) {
 	// read configuration from examples directory to test valid application configuration
 	r := path.Join("../../examples", "application")
-	caseNames := make([]string, 0)
-	err := filepath.WalkDir(r, func(path string, d fs.DirEntry, err error) error {
-		if d.IsDir() {
-			return nil
-		}
-
-		caseNames = append(caseNames, path)
-
-		return nil
-	})
-	assert.NoError(t, err)
+	caseNames := getCase(t, r)
 
 	wh := &ApplicationWebhook{}
 	for _, tt := range caseNames {
@@ -60,17 +50,7 @@ func TestValidApplicationValidation(t *testing.T) {
 
 func TestInvalidApplicationValidation(t *testing.T) {
 	r := path.Join("testdata", "application")
-	caseNames := make([]string, 0)
-	err := filepath.WalkDir(r, func(path string, d fs.DirEntry, err error) error {
-		if d.IsDir() {
-			return nil
-		}
-
-		caseNames = append(caseNames, path)
-
-		return nil
-	})
-	assert.NoError(t, err)
+	caseNames := getCase(t, r)
 
 	wh := &ApplicationWebhook{}
 	for _, tt := range caseNames {
@@ -84,6 +64,26 @@ func TestInvalidApplicationValidation(t *testing.T) {
 			t.Logf("%v", err)
 		})
 	}
+}
+
+func getCase(t *testing.T, r string) []string {
+	caseNames := make([]string, 0)
+	err := filepath.WalkDir(r, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if path == r {
+				return nil
+			} else {
+				return filepath.SkipDir
+			}
+		}
+		caseNames = append(caseNames, path)
+		return nil
+	})
+	assert.NoError(t, err)
+	return caseNames
 }
 
 func readApplication(filename string) (*v1alpha1.Application, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
 Allow setting the application's destination to a cluster, reducing the operational steps and enabling users to seamlessly use Kurator in a single-cluster, thereby increasing Kurator's flexibility.
﻿
**Which issue(s) this PR fixes**:
Fixes #653 

**Does this PR introduce a user-facing change?**:
The application can be directly deployed to the current host cluster through the following configuration
```release-note
apiVersion: apps.kurator.dev/v1alpha1
kind: Application
metadata:
  name: rollout-demo
  namespace: default
spec:
  source:
    gitRepository:
      interval: 3m0s
      ref:
        branch: master
      timeout: 1m0s
      url: https://github.com/stefanprodan/podinfo
  syncPolicies:
    - kustomization:
        interval: 0s
        path: ./deploy/webapp
        prune: true
        timeout: 2m0s
    - kustomization:
        targetNamespace: default
        interval: 5m0s
        path: ./kustomize
        prune: true
        timeout: 2m0s
```

