### PR TITLE
Update stale Helm install flag

### DIFF
--- a/cmd/cluster-operator/README.md
+++ b/cmd/cluster-operator/README.md
@@ -16,7 +16,7 @@ kind load docker-image ghcr.io/kurator-dev/cluster-operator:0.3-dev --name <your
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 kubectl create namespace cert-manager
-helm install -n cert-manager cert-manager jetstack/cert-manager --set installCRDs=true
+helm install -n cert-manager cert-manager jetstack/cert-manager --set crds.enabled=true
 ```
 
 - Install cluster operator

--- a/cmd/cluster-operator/README.md
+++ b/cmd/cluster-operator/README.md
@@ -16,7 +16,7 @@ kind load docker-image ghcr.io/kurator-dev/cluster-operator:0.3-dev --name <your
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 kubectl create namespace cert-manager
-helm install -n cert-manager cert-manager jetstack/cert-manager --set crds.enabled=true
+helm install -n cert-manager cert-manager jetstack/cert-manager --set crds.enabled=true --version v1.15.3
 ```
 
 - Install cluster operator

--- a/docs/content/en/boilerplates/prerequisites.md
+++ b/docs/content/en/boilerplates/prerequisites.md
@@ -43,5 +43,5 @@ Kurator cluster operator depends on [cert manager CA injector](https://cert-mana
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 kubectl create namespace cert-manager
-helm install -n cert-manager cert-manager jetstack/cert-manager --set crds.enabled=true
+helm install -n cert-manager cert-manager jetstack/cert-manager --set crds.enabled=true --version v1.15.3
 ```

--- a/docs/content/en/boilerplates/prerequisites.md
+++ b/docs/content/en/boilerplates/prerequisites.md
@@ -43,5 +43,5 @@ Kurator cluster operator depends on [cert manager CA injector](https://cert-mana
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 kubectl create namespace cert-manager
-helm install -n cert-manager cert-manager jetstack/cert-manager --set installCRDs=true
+helm install -n cert-manager cert-manager jetstack/cert-manager --set crds.enabled=true
 ```

--- a/hack/e2e-test/install-kurator.sh
+++ b/hack/e2e-test/install-kurator.sh
@@ -17,7 +17,7 @@ VERSION=$(echo "$VERSION" | sed 's/^0*//')
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 kubectl create namespace cert-manager
-helm install -n cert-manager cert-manager jetstack/cert-manager --set installCRDs=true
+helm install -n cert-manager cert-manager jetstack/cert-manager --set crds.enabled=true
 
 helm repo add fluxcd-community https://fluxcd-community.github.io/helm-charts
 cat <<EOF | helm install fluxcd fluxcd-community/flux2 --version 2.7.0 -n fluxcd-system --create-namespace -f -

--- a/hack/e2e-test/install-kurator.sh
+++ b/hack/e2e-test/install-kurator.sh
@@ -17,7 +17,7 @@ VERSION=$(echo "$VERSION" | sed 's/^0*//')
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 kubectl create namespace cert-manager
-helm install -n cert-manager cert-manager jetstack/cert-manager --set crds.enabled=true
+helm install -n cert-manager cert-manager jetstack/cert-manager --set crds.enabled=true --version v1.15.3
 
 helm repo add fluxcd-community https://fluxcd-community.github.io/helm-charts
 cat <<EOF | helm install fluxcd fluxcd-community/flux2 --version 2.7.0 -n fluxcd-system --create-namespace -f -


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind cleanup

**What this PR does / why we need it**:

Helm install flag `installcrds` is deprecated, use `crds.enabled` instead.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

