### PR TITLE
Feat: Add customizable Metrics Analysis to the rollout API 

### DIFF
--- a/docs/content/en/references/apps_v1alpha1_types.html
+++ b/docs/content/en/references/apps_v1alpha1_types.html
@@ -1616,7 +1616,8 @@ MetricName
 </td>
 <td>
 <p>Name of the metric.
-Currently supported metric are <code>request-success-rate</code> and <code>request-duration</code>.</p>
+Currently supported metric are <code>request-success-rate</code> and <code>request-duration</code>.
+When Name is not <code>request-success-rate</code> or <code>request-duration</code>, you need to define the metric rule in CustomMetric.</p>
 </td>
 </tr>
 <tr>
@@ -1644,6 +1645,18 @@ CanaryThresholdRange
 <em>(Optional)</em>
 <p>ThresholdRange defines valid value accepted for this metric.
 If no thresholdRange are set, Kurator will default every check is successful.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>customMetric</code><br>
+<em>
+github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1.MetricTemplateSpec
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CustomMetric defines the metric template to be used for this metric.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/content/en/references/apps_v1alpha1_types.html
+++ b/docs/content/en/references/apps_v1alpha1_types.html
@@ -1616,8 +1616,9 @@ MetricName
 </td>
 <td>
 <p>Name of the metric.
-Currently supported metric are <code>request-success-rate</code> and <code>request-duration</code>.
-When Name is not <code>request-success-rate</code> or <code>request-duration</code>, you need to define the metric rule in CustomMetric.</p>
+Currently internally supported metric are <code>request-success-rate</code> and <code>request-duration</code>.
+And you can use the metrics that come with the gateway.
+When you define a metric rule in <code>CustomMetric</code>, fill in the custom name in this field.</p>
 </td>
 </tr>
 <tr>

--- a/examples/rollout/canaryWithCustomMetric.yaml
+++ b/examples/rollout/canaryWithCustomMetric.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps.kurator.dev/v1alpha1
+kind: Application
+metadata:
+  name: CustomMetric-demo
+  namespace: default
+spec:
+  source:
+    gitRepository:
+      interval: 3m0s
+      ref:
+        branch: master
+      timeout: 1m0s
+      url: https://github.com/stefanprodan/podinfo
+  syncPolicies:
+    - destination:
+        fleet: quickstart
+      kustomization:
+        interval: 0s
+        path: ./deploy/webapp
+        prune: true
+        timeout: 2m0s
+      rollout:
+        testLoader: true
+        trafficRoutingProvider: istio
+        workload:
+          apiVersion: apps/v1
+          name: backend
+          kind: Deployment
+          namespace: webapp
+        serviceName: backend
+        port: 9898
+        rolloutPolicy:
+          trafficRouting:
+            timeoutSeconds: 60
+            gateways:
+            - istio-system/public-gateway
+            hosts:
+            - backend.webapp
+            canaryStrategy:
+              maxWeight: 50
+              stepWeight: 10
+          trafficAnalysis:
+             checkIntervalSeconds: 90
+             checkFailedTimes: 2
+             metrics:
+             - name: request-success-rate
+               intervalSeconds: 90
+               thresholdRange:
+                 min: 99
+             - name: my-metric
+               intervalSeconds: 90
+               thresholdRange:
+                 max: 99
+               customMetric: 
+                 provider: 
+                   type: prometheus
+                   address: http://flagger-prometheus.ingress-nginx:9090
+                 query: |
+                   sum(
+                     rate(
+                       http_requests_total{
+                         status!~"5.*"
+                       }[{{ interval }}]
+                     )
+                   )
+                   /
+                   sum(
+                     rate(
+                       http_requests_total[{{ interval }}]
+                     )
+                   ) * 100
+             webhooks:
+                 timeoutSeconds: 60
+                 command:
+                 - "hey -z 1m -q 10 -c 2 http://backend-canary.webapp:9898/"
+          rolloutTimeoutSeconds: 600
+    - destination:
+        fleet: quickstart
+      kustomization:
+        targetNamespace: default
+        interval: 5m0s
+        path: ./kustomize
+        prune: true
+        timeout: 2m0s

--- a/manifests/charts/fleet-manager/crds/apps.kurator.dev_applications.yaml
+++ b/manifests/charts/fleet-manager/crds/apps.kurator.dev_applications.yaml
@@ -1362,8 +1362,9 @@ spec:
                                       name:
                                         description: |-
                                           Name of the metric.
-                                          Currently supported metric are `request-success-rate` and `request-duration`.
-                                          When Name is not `request-success-rate` or `request-duration`, you need to define the metric rule in CustomMetric.
+                                          Currently internally supported metric are `request-success-rate` and `request-duration`.
+                                          And you can use the metrics that come with the gateway.
+                                          When you define a metric rule in `CustomMetric`, fill in the custom name in this field.
                                         type: string
                                       thresholdRange:
                                         description: |-

--- a/manifests/charts/fleet-manager/crds/apps.kurator.dev_applications.yaml
+++ b/manifests/charts/fleet-manager/crds/apps.kurator.dev_applications.yaml
@@ -1315,6 +1315,45 @@ spec:
                                     If you want use custom checks, you can refer to https://docs.flagger.app/usage/metrics#custom-metrics.
                                   items:
                                     properties:
+                                      customMetric:
+                                        description: CustomMetric defines the metric
+                                          template to be used for this metric.
+                                        properties:
+                                          provider:
+                                            description: Provider of this metric
+                                            properties:
+                                              address:
+                                                description: HTTP(S) address of this
+                                                  provider
+                                                type: string
+                                              insecureSkipVerify:
+                                                description: InsecureSkipVerify disables
+                                                  certificate verification for the
+                                                  provider
+                                                type: boolean
+                                              region:
+                                                description: Region of the provider
+                                                type: string
+                                              secretRef:
+                                                description: Secret reference containing
+                                                  the provider credentials
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              type:
+                                                description: Type of provider
+                                                type: string
+                                            type: object
+                                          query:
+                                            description: Query template for this metric
+                                            type: string
+                                        type: object
                                       intervalSeconds:
                                         description: |-
                                           IntervalSeconds defines metrics query interval.
@@ -1324,6 +1363,7 @@ spec:
                                         description: |-
                                           Name of the metric.
                                           Currently supported metric are `request-success-rate` and `request-duration`.
+                                          When Name is not `request-success-rate` or `request-duration`, you need to define the metric rule in CustomMetric.
                                         type: string
                                       thresholdRange:
                                         description: |-

--- a/pkg/apis/apps/v1alpha1/types.go
+++ b/pkg/apis/apps/v1alpha1/types.go
@@ -339,8 +339,9 @@ type TrafficAnalysis struct {
 
 type Metric struct {
 	// Name of the metric.
-	// Currently supported metric are `request-success-rate` and `request-duration`.
-	// When Name is not `request-success-rate` or `request-duration`, you need to define the metric rule in CustomMetric.
+	// Currently internally supported metric are `request-success-rate` and `request-duration`.
+	// And you can use the metrics that come with the gateway.
+	// When you define a metric rule in `CustomMetric`, fill in the custom name in this field.
 	Name MetricName `json:"name"`
 
 	// IntervalSeconds defines metrics query interval.

--- a/pkg/apis/apps/v1alpha1/types.go
+++ b/pkg/apis/apps/v1alpha1/types.go
@@ -340,6 +340,7 @@ type TrafficAnalysis struct {
 type Metric struct {
 	// Name of the metric.
 	// Currently supported metric are `request-success-rate` and `request-duration`.
+	// When Name is not `request-success-rate` or `request-duration`, you need to define the metric rule in CustomMetric.
 	Name MetricName `json:"name"`
 
 	// IntervalSeconds defines metrics query interval.
@@ -350,6 +351,10 @@ type Metric struct {
 	// If no thresholdRange are set, Kurator will default every check is successful.
 	// +optional
 	ThresholdRange *CanaryThresholdRange `json:"thresholdRange,omitempty"`
+
+	// CustomMetric defines the metric template to be used for this metric.
+	// +optional
+	CustomMetric *flaggerv1b1.MetricTemplateSpec `json:"customMetric,omitempty"`
 }
 
 type MetricName string

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -669,6 +669,11 @@ func (in *Metric) DeepCopyInto(out *Metric) {
 		*out = new(CanaryThresholdRange)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CustomMetric != nil {
+		in, out := &in.CustomMetric, &out.CustomMetric
+		*out = new(v1beta1.MetricTemplateSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/fleet-manager/application/rollout_helper.go
+++ b/pkg/fleet-manager/application/rollout_helper.go
@@ -26,9 +26,11 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
 
 	applicationapi "kurator.dev/kurator/pkg/apis/apps/v1alpha1"
@@ -148,6 +150,9 @@ func (a *ApplicationManager) syncRolloutPolicyForCluster(ctx context.Context,
 		} else {
 			canaryInCluster.Spec.Service = *canaryService
 		}
+		if err := applyMetricTemplate(ctx, fleetClusterClient, rolloutPolicy.RolloutPolicy.TrafficAnalysis.Metrics, rolloutPolicy.Workload.Namespace, policyName); err != nil {
+			return ctrl.Result{}, err
+		}
 		canaryInCluster.Spec.Analysis = renderCanaryAnalysis(*rolloutPolicy, clusterKey.Name)
 		// Set up annotations to make sure it's a resource created by kurator
 		canaryInCluster.SetAnnotations(annotation)
@@ -232,6 +237,18 @@ func (a *ApplicationManager) deleteResourcesInMemberClusters(ctx context.Context
 			Namespace: rolloutPolicy.Workload.Namespace,
 			Name:      rolloutPolicy.ServiceName,
 		}
+
+		allMetricTemplateNamespaceName := make([]types.NamespacedName, 0, len(rolloutPolicy.RolloutPolicy.TrafficAnalysis.Metrics))
+		for _, metric := range rolloutPolicy.RolloutPolicy.TrafficAnalysis.Metrics {
+			if metric.CustomMetric != nil {
+				metricTemplateNamespaceName := types.NamespacedName{
+					Name:      string(metric.Name),
+					Namespace: rolloutPolicy.Workload.Namespace,
+				}
+				allMetricTemplateNamespaceName = append(allMetricTemplateNamespaceName, metricTemplateNamespaceName)
+			}
+		}
+
 		testloaderNamespaceName := types.NamespacedName{
 			Namespace: rolloutPolicy.Workload.Namespace,
 			Name:      rolloutPolicy.Workload.Name + "-testloader",
@@ -245,6 +262,9 @@ func (a *ApplicationManager) deleteResourcesInMemberClusters(ctx context.Context
 			testloaderSvc := &corev1.Service{}
 			if err := deleteResourceCreatedByKurator(ctx, testloaderNamespaceName, newClient, testloaderSvc); err != nil {
 				return errors.Wrapf(err, "failed to delete testloader service")
+			}
+			if err := deleteMetricTemplateName(ctx, allMetricTemplateNamespaceName, newClient); err != nil {
+				return err
 			}
 			canary := &flaggerv1b1.Canary{}
 			if err := deleteResourceCreatedByKurator(ctx, serviceNamespaceName, newClient, canary); err != nil {
@@ -335,6 +355,16 @@ func installPrivateTestloader(ctx context.Context, namespacedName types.Namespac
 	return nil
 }
 
+func deleteMetricTemplateName(ctx context.Context, allNamespaceName []types.NamespacedName, kubeClient client.Client) error {
+	metricTemplate := &flaggerv1b1.MetricTemplate{}
+	for _, namespaceName := range allNamespaceName {
+		if err := deleteResourceCreatedByKurator(ctx, namespaceName, kubeClient, metricTemplate); err != nil {
+			return errors.Wrapf(err, "failed to delete MetricTemplate")
+		}
+	}
+	return nil
+}
+
 func deleteResourceCreatedByKurator(ctx context.Context, namespaceName types.NamespacedName, kubeClient client.Client, obj client.Object) error {
 	if err := kubeClient.Get(ctx, namespaceName, obj); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -404,6 +434,31 @@ func renderCanaryService(rolloutPolicy applicationapi.RolloutConfig, service *co
 	return canaryService, nil
 }
 
+func applyMetricTemplate(ctx context.Context, fleetClusterClient client.Client, metrics []applicationapi.Metric, namespace, policyName string) error {
+	log := ctrl.LoggerFrom(ctx)
+	for _, metric := range metrics {
+		if metric.CustomMetric != nil {
+			metricTemplate := &flaggerv1b1.MetricTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        string(metric.Name),
+					Namespace:   namespace,
+					Annotations: map[string]string{RolloutIdentifier: policyName},
+				},
+			}
+			res, err := controllerutil.CreateOrUpdate(ctx, fleetClusterClient, metricTemplate, func() error {
+				metricTemplate.Spec = *metric.CustomMetric
+				return nil
+			})
+
+			if err != nil {
+				return errors.Wrapf(err, "error apply MetricTemplate %s for canary", metric.Name)
+			}
+			log.Info("success apply", "MetricTemplate:", metric.Name, "result:", res)
+		}
+	}
+	return nil
+}
+
 func renderCanaryAnalysis(rolloutPolicy applicationapi.RolloutConfig, clusterName string) *flaggerv1b1.CanaryAnalysis {
 	canaryAnalysis := flaggerv1b1.CanaryAnalysis{
 		Iterations:      rolloutPolicy.RolloutPolicy.TrafficRouting.AnalysisTimes,
@@ -429,6 +484,12 @@ func renderCanaryAnalysis(rolloutPolicy applicationapi.RolloutConfig, clusterNam
 			Name:           string(metric.Name),
 			Interval:       metricInterval,
 			ThresholdRange: (*flaggerv1b1.CanaryThresholdRange)(metric.ThresholdRange),
+		}
+		if metric.Name != applicationapi.RequestSuccessRate && metric.Name != applicationapi.RequestDuration {
+			templateMetric.TemplateRef = &flaggerv1b1.CrossNamespaceObjectReference{
+				Name:      string(metric.Name),
+				Namespace: rolloutPolicy.Workload.Namespace,
+			}
 		}
 		canaryMetric = append(canaryMetric, templateMetric)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change
/kind feature

**What this PR does / why we need it**:
Providing users with customizable Metrics Analysis enables users to flexibly adjust according to different needs and scenarios, ensuring that users can obtain more accurate analysis results that meet specific business applications, thereby improving the operability of the system and the accuracy of data analysis.

**Which issue(s) this PR fixes**:
Fixes #681 


**Does this PR introduce a user-facing change?**:

```release-note
    ......
          trafficAnalysis:
             checkIntervalSeconds: 90
             checkFailedTimes: 2
             metrics:
             - name: request-success-rate
               intervalSeconds: 90
               thresholdRange:
                 min: 99
             - name: my-metric
               intervalSeconds: 90
               thresholdRange:
                 max: 99
               customMetric: 
                 provider: 
                   type: prometheus
                   address: http://flagger-prometheus.ingress-nginx:9090
                 query: |
                   sum(
                     rate(
                       http_requests_total{
                         status!~"5.*"
                       }[{{ interval }}]
                     )
                   )
                   /
                   sum(
                     rate(
                       http_requests_total[{{ interval }}]
                     )
                   ) * 100
             webhooks:
                 timeoutSeconds: 60
                 command:
                 - "hey -z 1m -q 10 -c 2 http://backend-canary.webapp:9898/"
    ......
```

